### PR TITLE
Disable FR, IR and PR by default on system_traces.* table

### DIFF
--- a/src/java/org/apache/cassandra/schema/TableMetadata.java
+++ b/src/java/org/apache/cassandra/schema/TableMetadata.java
@@ -978,6 +978,17 @@ public class TableMetadata implements SchemaElement
             return this;
         }
 
+        public Builder automatedRepairFull(AutoRepairParams val)
+        {
+            params.automatedRepairFull(val);
+            return this;
+        }
+
+        public Builder automatedRepairIncremental(AutoRepairParams val)
+        {
+            params.automatedRepairIncremental(val);
+            return this;
+        }
 
         public Builder isCounter(boolean val)
         {

--- a/src/java/org/apache/cassandra/tracing/TraceKeyspace.java
+++ b/src/java/org/apache/cassandra/tracing/TraceKeyspace.java
@@ -21,6 +21,7 @@ import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.*;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
@@ -29,6 +30,8 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.rows.Row;
+import org.apache.cassandra.repair.autorepair.AutoRepairConfig;
+import org.apache.cassandra.schema.AutoRepairParams;
 import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.KeyspaceParams;
 import org.apache.cassandra.schema.SchemaConstants;
@@ -101,6 +104,8 @@ public final class TraceKeyspace
                                    .id(TableId.forSystemTable(SchemaConstants.TRACE_KEYSPACE_NAME, table))
                                    .gcGraceSeconds(0)
                                    .comment(description)
+                                   .automatedRepairFull(AutoRepairParams.fromMap(AutoRepairConfig.RepairType.full, ImmutableMap.of(AutoRepairParams.Option.ENABLED.toString(), Boolean.toString(false))))
+                                   .automatedRepairIncremental(AutoRepairParams.fromMap(AutoRepairConfig.RepairType.incremental, ImmutableMap.of(AutoRepairParams.Option.ENABLED.toString(), Boolean.toString(false))))
                                    .build();
     }
 

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
@@ -19,6 +19,9 @@
 package org.apache.cassandra.repair.autorepair;
 
 import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Collections;
 import java.util.Set;
@@ -34,8 +37,10 @@ import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.config.DurationSpec;
 import org.apache.cassandra.config.ParameterizedClass;
 import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.repair.autorepair.AutoRepairConfig.Options;
+import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.utils.FBUtilities;
 
 import static org.junit.Assert.assertEquals;
@@ -424,4 +429,35 @@ public class AutoRepairConfigTest extends CQLTester
         assert config.repair_type_overrides.get(repairType).repair_session_timeout.toSeconds() == 3600;
     }
 
+
+    @Test
+    public void testDefaultSystemTablesBehavior()
+    {
+        Map<String, List<String>> ksTablesRepairDefaultDisabled = new HashMap<>();
+        ksTablesRepairDefaultDisabled.put("system_traces", List.of("sessions", "events"));
+
+        Map<String, List<String>> ksTablesRepairDefaultEnabled = new HashMap<>();
+        ksTablesRepairDefaultEnabled.put("system_auth", List.of("role_permissions", "network_permissions", "role_members", "roles", "resource_role_permissons_index"));
+        ksTablesRepairDefaultEnabled.put("system_distributed", List.of("auto_repair_priority", "repair_history", "auto_repair_history", "view_build_status", "parent_repair_history", "partition_denylist"));
+
+        for (Map.Entry<String, List<String>> disabled : ksTablesRepairDefaultDisabled.entrySet())
+        {
+            for (String table : disabled.getValue())
+            {
+                TableMetadata sessionCfm = Keyspace.open(disabled.getKey()).getColumnFamilyStore(table).metadata();
+                assertFalse(disabled.getKey()+"."+table, sessionCfm.params.automatedRepair.get(AutoRepairConfig.RepairType.full).repairEnabled());
+                assertFalse(disabled.getKey()+"."+table, sessionCfm.params.automatedRepair.get(AutoRepairConfig.RepairType.incremental).repairEnabled());
+            }
+        }
+
+        for (Map.Entry<String, List<String>> enabled : ksTablesRepairDefaultEnabled.entrySet())
+        {
+            for (String table : enabled.getValue())
+            {
+                TableMetadata sessionCfm = Keyspace.open(enabled.getKey()).getColumnFamilyStore(table).metadata();
+                assertTrue(enabled.getKey()+"."+table, sessionCfm.params.automatedRepair.get(AutoRepairConfig.RepairType.full).repairEnabled());
+                assertTrue(enabled.getKey()+"."+table, sessionCfm.params.automatedRepair.get(AutoRepairConfig.RepairType.incremental).repairEnabled());
+            }
+        }
+    }
 }

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -420,8 +420,8 @@ public class AutoRepairParameterizedTest extends CQLTester
         // skipping both the tables - one table is due to its repair has been disabled, and another one due to high sstable count
         assertEquals(0, state.getSkippedTokenRangesCount());
         assertEquals(0, AutoRepairMetricsManager.getMetrics(repairType).skippedTokenRangesCount.getValue().intValue());
-        assertEquals(2, state.getSkippedTablesCount());
-        assertEquals(2, AutoRepairMetricsManager.getMetrics(repairType).skippedTablesCount.getValue().intValue());
+        assertEquals(4, state.getSkippedTablesCount());
+        assertEquals(4, AutoRepairMetricsManager.getMetrics(repairType).skippedTablesCount.getValue().intValue());
 
         // set it to higher value, and this time, the tables should not be skipped
         config.setRepairSSTableCountHigherThreshold(repairType, beforeCount);
@@ -433,8 +433,8 @@ public class AutoRepairParameterizedTest extends CQLTester
         assertEquals(1, AutoRepairMetricsManager.getMetrics(repairType).totalMVTablesConsideredForRepair.getValue().intValue());
         assertEquals(0, state.getSkippedTokenRangesCount());
         assertEquals(0, AutoRepairMetricsManager.getMetrics(repairType).skippedTokenRangesCount.getValue().intValue());
-        assertEquals(1, state.getSkippedTablesCount());
-        assertEquals(1, AutoRepairMetricsManager.getMetrics(repairType).skippedTablesCount.getValue().intValue());
+        assertEquals(3, state.getSkippedTablesCount());
+        assertEquals(3, AutoRepairMetricsManager.getMetrics(repairType).skippedTablesCount.getValue().intValue());
     }
 
     @Test
@@ -590,7 +590,7 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepair.instance.repair(repairType);
 
         assertEquals(1, shuffleKeyspacesCall.get());
-        assertEquals(5, shuffleTablesCall.get());
+        assertEquals(4, shuffleTablesCall.get());
     }
 
     @Test
@@ -629,10 +629,10 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepair.instance.repair(repairType);
 
         //system_auth.role_permissions,system_auth.network_permissions,system_auth.role_members,system_auth.roles,
-        // system_auth.resource_role_permissons_index,system_traces.sessions,system_traces.events,ks.tbl,
+        // system_auth.resource_role_permissons_index,ks.tbl,
         // system_distributed.auto_repair_priority,system_distributed.repair_history,system_distributed.auto_repair_history,
         // system_distributed.view_build_status,system_distributed.parent_repair_history,system_distributed.partition_denylist
-        int exptedTablesGoingThroughRepair = 18;
+        int exptedTablesGoingThroughRepair = 16;
         assertEquals(config.getRepairMaxRetries()*exptedTablesGoingThroughRepair, sleepCalls.get());
         verify(autoRepairState, Mockito.times(1)).setSucceededTokenRangesCount(0);
         verify(autoRepairState, Mockito.times(1)).setSkippedTokenRangesCount(0);


### PR DESCRIPTION
```
Since system_traces table does not contain the important information, running repair is not necessary. By default, disable repair on this system table.

patch by <Authors>; reviewed by <Reviewers> for CASSANDRA-20101

Co-authored-by: Name1 <email1>
Co-authored-by: Name2 <email2>

```

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-20101)

