### PR TITLE
Implement minimum repair task duration setting for auto-repair scheduler

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.1.6
+ * Implement minimum repair task duration setting for auto-repair scheduler (CASSANDRA-20160)
  * Implement preview_repaired auto-repair type (CASSANDRA-20046)
  * Refresh stale paxos commit (CASSANDRA-19617)
  * Reduce info logging from automatic paxos repair (CASSANDRA-19445)

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -325,11 +325,9 @@ public class AutoRepair
                         f = repairRunnableExecutors.get(repairType).submit(task);
                         try
                         {
-
                             long jobStartTime = timeFunc.get();
                             repairState.waitForRepairToComplete(config.getRepairSessionTimeout(repairType));
                             soakAfterRepair(jobStartTime, config.getRepairTaskMinDuration().toMilliseconds());
-
                         }
                         catch (InterruptedException e)
                         {

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -304,7 +304,9 @@ public class AutoRepair
                                         f = repairRunnableExecutors.get(repairType).submit(task);
                                         try
                                         {
+                                            long jobStartTime = timeFunc.get();
                                             repairState.waitForRepairToComplete(config.getRepairSessionTimeout(repairType));
+                                            soakAfterRepair(jobStartTime, config.getRepairTaskMinDuration().toMilliseconds());
                                         }
                                         catch (InterruptedException e)
                                         {
@@ -465,5 +467,17 @@ public class AutoRepair
     public AutoRepairState getRepairState(AutoRepairConfig.RepairType repairType)
     {
         return repairStates.get(repairType);
+    }
+
+    private void soakAfterRepair(long startTimeMilis, long minDurationMilis)
+    {
+        long currentTime = timeFunc.get();
+        long timeElapsed = currentTime - startTimeMilis;
+        if (timeElapsed < minDurationMilis)
+        {
+            long timeToSoak = minDurationMilis - timeElapsed;
+            logger.info("Soaking for {} ms after repair", timeToSoak);
+            sleepFunc.accept(timeToSoak, TimeUnit.MILLISECONDS);
+        }
     }
 }

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
@@ -50,6 +50,10 @@ public class AutoRepairConfig implements Serializable
     public volatile Integer repair_max_retries = 3;
     // the backoff time in seconds for retrying a repair session.
     public volatile DurationSpec.LongSecondsBound repair_retry_backoff = new DurationSpec.LongSecondsBound("30s");
+    // the minimum duration for the execution of a single repair task (i.e.: RepairRunnable).
+    // This helps prevent the auto-repair scheduler from overwhelming the node by scheduling a large number of
+    // repair tasks in a short period of time.
+    public volatile DurationSpec.LongSecondsBound repair_task_min_duration = new DurationSpec.LongSecondsBound("5s");
 
     // global_settings overides Options.defaultOptions for all repair types
     public volatile Options global_settings;
@@ -132,6 +136,16 @@ public class AutoRepairConfig implements Serializable
     public void setRepairRetryBackoff(String interval)
     {
         repair_retry_backoff = new DurationSpec.LongSecondsBound(interval);
+    }
+
+    public DurationSpec.LongSecondsBound getRepairTaskMinDuration()
+    {
+        return repair_task_min_duration;
+    }
+
+    public void setRepairTaskMinDuration(String duration)
+    {
+        repair_task_min_duration = new DurationSpec.LongSecondsBound(duration);
     }
 
     public boolean isAutoRepairEnabled(RepairType repairType)

--- a/src/java/org/apache/cassandra/service/AutoRepairService.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairService.java
@@ -19,6 +19,7 @@ package org.apache.cassandra.service;
 
 import org.apache.cassandra.config.CassandraRelevantProperties;
 import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.config.DurationSpec;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.repair.autorepair.AutoRepairConfig;
@@ -135,6 +136,12 @@ public class AutoRepairService implements AutoRepairServiceMBean
     public void setAutoRepairRetryBackoff(String interval)
     {
         config.setRepairRetryBackoff(interval);
+    }
+
+    @Override
+    public void setAutoRepairMinRepairTaskDuration(String duration)
+    {
+        config.setRepairTaskMinDuration(duration);
     }
 
     @Override

--- a/src/java/org/apache/cassandra/service/AutoRepairServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairServiceMBean.java
@@ -48,6 +48,8 @@ public interface AutoRepairServiceMBean
 
     public void setAutoRepairRetryBackoff(String interval);
 
+    public void setAutoRepairMinRepairTaskDuration(String duration);
+
     public void setRepairSSTableCountHigherThreshold(RepairType repairType, int ssTableHigherThreshold);
 
     public void setAutoRepairTableMaxRepairTime(RepairType repairType, String autoRepairTableMaxRepairTime);

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -2200,6 +2200,11 @@ public class NodeProbe implements AutoCloseable
         autoRepairProxy.setAutoRepairRetryBackoff(interval);
     }
 
+    public void setAutoRepairMinRepairTaskDuration(String duration)
+    {
+        autoRepairProxy.setAutoRepairMinRepairTaskDuration(duration);
+    }
+
     public void setRepairSSTableCountHigherThreshold(AutoRepairConfig.RepairType repairType, int ssTableHigherThreshold)
     {
         autoRepairProxy.setRepairSSTableCountHigherThreshold(repairType, ssTableHigherThreshold);

--- a/src/java/org/apache/cassandra/tools/nodetool/GetAutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetAutoRepairConfig.java
@@ -49,6 +49,7 @@ public class GetAutoRepairConfig extends NodeToolCmd
         sb.append("\n\tTTL for repair history for dead nodes: " + config.getAutoRepairHistoryClearDeleteHostsBufferInterval());
         sb.append("\n\tmax retries for repair: " + config.getRepairMaxRetries());
         sb.append("\n\tretry backoff: " + config.getRepairRetryBackoff());
+        sb.append("\n\tmin repair job duration: " + config.getRepairTaskMinDuration().toSeconds() + " seconds");
         for (RepairType repairType : RepairType.values())
         {
             sb.append(formatRepairTypeConfig(probe, repairType, config));

--- a/src/java/org/apache/cassandra/tools/nodetool/SetAutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/SetAutoRepairConfig.java
@@ -46,7 +46,8 @@ public class SetAutoRepairConfig extends NodeToolCmd
                   "[number_of_repair_threads|number_of_subranges|min_repair_interval|sstable_upper_threshold" +
                   "|enabled|table_max_repair_time|priority_hosts|forcerepair_hosts|ignore_dcs" +
                   "|history_clear_delete_hosts_buffer_interval|repair_primary_token_range_only" +
-                  "|parallel_repair_count|parallel_repair_percentage|mv_repair_enabled|repair_max_retries|repair_retry_backoff|repair_session_timeout]",
+                  "|parallel_repair_count|parallel_repair_percentage|mv_repair_enabled|repair_max_retries" +
+                  "|repair_retry_backoff|repair_session_timeout|min_repair_task_duration]",
     required = true)
     protected List<String> args = new ArrayList<>();
 
@@ -81,6 +82,9 @@ public class SetAutoRepairConfig extends NodeToolCmd
                 return;
             case "repair_retry_backoff":
                 probe.setAutoRepairRetryBackoff(paramVal);
+                return;
+            case "min_repair_task_duration":
+                probe.setAutoRepairMinRepairTaskDuration(paramVal);
                 return;
             default:
                 // proceed to options that require --repair-type option

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
@@ -91,13 +91,21 @@ public class AutoRepairConfigTest extends CQLTester
     }
 
     @Test
+    public void testRepairMinDuration()
+    {
+        config = new AutoRepairConfig(false);
+
+        config.setRepairTaskMinDuration("3s");
+        assertEquals(3L, config.getRepairTaskMinDuration().toSeconds());
+    }
+
+    @Test
     public void testIsAutoRepairEnabledReturnsTrueWhenRepairIsDisabledGlobally()
     {
         config = new AutoRepairConfig(false);
         config.global_settings.enabled = true;
         assertFalse(config.isAutoRepairEnabled(repairType));
     }
-
 
     @Test
     public void testIsAutoRepairEnabledReturnsTrueWhenRepairIsDisabledForRepairType()

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -107,6 +107,12 @@ public class AutoRepairParameterizedTest extends CQLTester
     RepairRunnable repairRunnable;
     private static AutoRepairConfig defaultConfig;
 
+    //system_auth.role_permissions,system_auth.network_permissions,system_auth.role_members,system_auth.roles,
+    // system_auth.resource_role_permissons_index,system_traces.sessions,system_traces.events,ks.tbl,
+    // system_distributed.auto_repair_priority,system_distributed.repair_history,system_distributed.auto_repair_history,
+    // system_distributed.view_build_status,system_distributed.parent_repair_history,system_distributed.partition_denylist
+    private final int expectedTablesGoingThroughRepair = 14;
+
 
     @Parameterized.Parameter()
     public AutoRepairConfig.RepairType repairType;
@@ -182,6 +188,7 @@ public class AutoRepairParameterizedTest extends CQLTester
 
         timeFuncCalls = 0;
         AutoRepair.timeFunc = System::currentTimeMillis;
+        AutoRepair.sleepFunc = (Long startTime, TimeUnit unit) -> {};
         resetCounters();
         resetConfig();
 
@@ -220,6 +227,7 @@ public class AutoRepairParameterizedTest extends CQLTester
         config.global_settings = defaultConfig.global_settings;
         config.history_clear_delete_hosts_buffer_interval = defaultConfig.history_clear_delete_hosts_buffer_interval;
         config.setRepairSubRangeNum(repairType, 1);
+        config.repair_task_min_duration = new DurationSpec.LongSecondsBound("0s");
     }
 
     private void executeCQL()
@@ -666,15 +674,10 @@ public class AutoRepairParameterizedTest extends CQLTester
 
         AutoRepair.instance.repair(repairType);
 
-        //system_auth.role_permissions,system_auth.network_permissions,system_auth.role_members,system_auth.roles,
-        // system_auth.resource_role_permissons_index,system_traces.sessions,system_traces.events,ks.tbl,
-        // system_distributed.auto_repair_priority,system_distributed.repair_history,system_distributed.auto_repair_history,
-        // system_distributed.view_build_status,system_distributed.parent_repair_history,system_distributed.partition_denylist
-        int exptedTablesGoingThroughRepair = 14;
-        assertEquals(config.getRepairMaxRetries()*exptedTablesGoingThroughRepair, sleepCalls.get());
+        assertEquals(config.getRepairMaxRetries()*expectedTablesGoingThroughRepair, sleepCalls.get());
         verify(autoRepairState, Mockito.times(1)).setSucceededTokenRangesCount(0);
         verify(autoRepairState, Mockito.times(1)).setSkippedTokenRangesCount(0);
-        verify(autoRepairState, Mockito.times(1)).setFailedTokenRangesCount(exptedTablesGoingThroughRepair);
+        verify(autoRepairState, Mockito.times(1)).setFailedTokenRangesCount(expectedTablesGoingThroughRepair);
     }
 
     @Test
@@ -700,7 +703,7 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepair.instance.repair(repairType);
 
         assertEquals(1, sleepCalls.get());
-        verify(autoRepairState, Mockito.times(1)).setSucceededTokenRangesCount(14);
+        verify(autoRepairState, Mockito.times(1)).setSucceededTokenRangesCount(expectedTablesGoingThroughRepair);
         verify(autoRepairState, Mockito.times(1)).setSkippedTokenRangesCount(0);
         verify(autoRepairState, Mockito.times(1)).setFailedTokenRangesCount(0);
     }
@@ -750,5 +753,50 @@ public class AutoRepairParameterizedTest extends CQLTester
         {
             AutoRepair.instance.repair(repairType);
         }
+    }
+
+
+    @Test
+    public void testSoakAfterImmediateRepair()
+    {
+        when(autoRepairState.getRepairRunnable(any(), any(), any(), anyBoolean())).thenReturn(repairRunnable);
+        when(autoRepairState.isSuccess()).thenReturn(true);
+        AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
+        config.repair_task_min_duration = new DurationSpec.LongSecondsBound("1s");
+        AtomicInteger sleepCalls = new AtomicInteger();
+        AutoRepair.sleepFunc = (Long duration, TimeUnit unit) -> {
+            sleepCalls.getAndIncrement();
+            assertEquals(TimeUnit.MILLISECONDS, unit);
+            assertTrue(config.getRepairTaskMinDuration().toMilliseconds() >= duration);
+        };
+        config.setRepairMinInterval(repairType, "0s");
+        AutoRepair.instance.repairStates.put(repairType, autoRepairState);
+
+        AutoRepair.instance.repair(repairType);
+
+        assertEquals(expectedTablesGoingThroughRepair, sleepCalls.get());
+        verify(autoRepairState, Mockito.times(1)).setSucceededTokenRangesCount(expectedTablesGoingThroughRepair);
+        verify(autoRepairState, Mockito.times(1)).setSkippedTokenRangesCount(0);
+        verify(autoRepairState, Mockito.times(1)).setFailedTokenRangesCount(0);
+    }
+
+    @Test
+    public void testNoSoakAfterRepair()
+    {
+        when(autoRepairState.getRepairRunnable(any(), any(), any(), anyBoolean())).thenReturn(repairRunnable);
+        when(autoRepairState.isSuccess()).thenReturn(true);
+        AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
+        config.repair_task_min_duration = new DurationSpec.LongSecondsBound("0s");
+        AutoRepair.sleepFunc = (Long duration, TimeUnit unit) -> {
+            fail("Should not sleep after repair");
+        };
+        config.setRepairMinInterval(repairType, "0s");
+        AutoRepair.instance.repairStates.put(repairType, autoRepairState);
+
+        AutoRepair.instance.repair(repairType);
+
+        verify(autoRepairState, Mockito.times(1)).setSucceededTokenRangesCount(expectedTablesGoingThroughRepair);
+        verify(autoRepairState, Mockito.times(1)).setSkippedTokenRangesCount(0);
+        verify(autoRepairState, Mockito.times(1)).setFailedTokenRangesCount(0);
     }
 }

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -784,7 +784,6 @@ public class AutoRepairParameterizedTest extends CQLTester
         }
     }
 
-
     @Test
     public void testSoakAfterImmediateRepair()
     {

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -107,12 +107,11 @@ public class AutoRepairParameterizedTest extends CQLTester
     RepairRunnable repairRunnable;
     private static AutoRepairConfig defaultConfig;
 
-    //system_auth.role_permissions,system_auth.network_permissions,system_auth.role_members,system_auth.roles,
+    // system_auth.role_permissions,system_auth.network_permissions,system_auth.role_members,system_auth.roles,
     // system_auth.resource_role_permissons_index,system_traces.sessions,system_traces.events,ks.tbl,
     // system_distributed.auto_repair_priority,system_distributed.repair_history,system_distributed.auto_repair_history,
     // system_distributed.view_build_status,system_distributed.parent_repair_history,system_distributed.partition_denylist
     private final int expectedTablesGoingThroughRepair = 14;
-
 
     @Parameterized.Parameter()
     public AutoRepairConfig.RepairType repairType;

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -790,19 +790,20 @@ public class AutoRepairParameterizedTest extends CQLTester
         when(autoRepairState.getRepairRunnable(any(), any(), any(), anyBoolean())).thenReturn(repairRunnable);
         when(autoRepairState.isSuccess()).thenReturn(true);
         AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
-        config.repair_task_min_duration = new DurationSpec.LongSecondsBound("1s");
+        config.repair_task_min_duration = new DurationSpec.LongSecondsBound("10s");
         AtomicInteger sleepCalls = new AtomicInteger();
         AutoRepair.sleepFunc = (Long duration, TimeUnit unit) -> {
             sleepCalls.getAndIncrement();
             assertEquals(TimeUnit.MILLISECONDS, unit);
             assertTrue(config.getRepairTaskMinDuration().toMilliseconds() >= duration);
+            config.repair_task_min_duration = new DurationSpec.LongSecondsBound("0s");
         };
         config.setRepairMinInterval(repairType, "0s");
         AutoRepair.instance.repairStates.put(repairType, autoRepairState);
 
         AutoRepair.instance.repair(repairType);
 
-        assertEquals(expectedTablesGoingThroughRepair, sleepCalls.get());
+        assertEquals(1, sleepCalls.get());
         verify(autoRepairState, Mockito.times(1)).setSucceededTokenRangesCount(expectedTablesGoingThroughRepair);
         verify(autoRepairState, Mockito.times(1)).setSkippedTokenRangesCount(0);
         verify(autoRepairState, Mockito.times(1)).setFailedTokenRangesCount(0);

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetAutoRepairConfigTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetAutoRepairConfigTest.java
@@ -105,7 +105,6 @@ public class SetAutoRepairConfigTest
             verify(probe, times(1)).setAutoRepairMaxRetriesCount(2);
         }
 
-
         @Test
         public void testRetryBackoffInSec()
         {
@@ -115,6 +114,17 @@ public class SetAutoRepairConfigTest
 
             verify(probe, times(1)).setAutoRepairRetryBackoff("3s");
         }
+
+        @Test
+        public void testMinRepairDuration()
+        {
+            cmd.args = ImmutableList.of("min_repair_task_duration", "4s");
+
+            cmd.execute(probe);
+
+            verify(probe, times(1)).setAutoRepairMinRepairTaskDuration("4s");
+        }
+
     }
 
     @RunWith(Parameterized.class)


### PR DESCRIPTION
Jira: CASSANDRA-20160

Implement a new config field for the auto-repair scheduler which sets a minimum duration for a repair task. We have observed that the auto-repair scheduler has the capacity to overload the cluster if it schedules too many repair tasks within a short period of time. This new config allows preventing such issues by rate limiting the scheduling of new repair tasks.

## Tests
### nodetool

1. Get default config:
```
$ nodetool getautorepairconfig
repair scheduler configuration:
	repair eligibility check interval: 5m
	TTL for repair history for dead nodes: 2h
	max retries for repair: 3
	retry backoff: 30s
	min repair job duration: 5 seconds

                ... other configs
```
2. Update config:
```
$ nodetool setautorepairconfig min_repair_task_duration 10s
```
3. Get modified config:
```
$ nodetool getautorepairconfig
repair scheduler configuration:
	repair eligibility check interval: 5m
	TTL for repair history for dead nodes: 2h
	max retries for repair: 3
	retry backoff: 30s
	min repair job duration: 10 seconds

                ... other configs
```

### min duration config
1. Create 3 node cluster with the following auto-repair config:
```
auto_repair:
  enabled: true
  repair_check_interval: 10s
  repair_type_overrides:
    full:
      enabled: true
      min_repair_interval: 10s
```
2. Since this cluster is empty, repair tasks will be very quick, this means we will soak after every repair job and this should be visible in the logs:
```
NFO  [AutoRepair-RepairRunnable-full:1] 2024-12-20 08:45:05,123 RepairRunnable.java:327 - Starting repair command #81 (c3af5c20-bef1-11ef-830c-11e11afe1701), repairing keyspace system_distributed with repair options (parallelism: parallel, primary range: true, incremental: false, job threads: 1, ColumnFamilies: [repair_history], dataCenters: [], hosts: [], previewKind: NONE, # of ranges: 1, pull repair: false, force repair: false, optimise streams: true, ignore unreplicated keyspaces: true, repairPaxos: false, paxosOnly: false)

     ... some logs about Merkle trees and sync tasks

INFO  [Repair#81:1] 2024-12-20 08:45:05,267 RepairSession.java:336 - [repair #c3b109d0-bef1-11ef-830c-11e11afe1701] Session completed successfully
INFO  [Repair#81:1] 2024-12-20 08:45:05,269 RepairRunnable.java:181 - Repair session c3b109d0-bef1-11ef-830c-11e11afe1701 for range [(3074457345618258602,3458764513820540927]] finished
INFO  [Repair#81:1] 2024-12-20 08:45:05,275 RepairRunnable.java:232 - [repair #c3af5c20-bef1-11ef-830c-11e11afe1701]Repair command #81 finished in 0 seconds
INFO  [AutoRepair-Repair-full:1] 2024-12-20 08:45:05,275 AutoRepair.java:501 - Soaking for 4847 ms after repair
```

3. Set min repair duration to 0s via nodetool setautorepairconfig:
```
$ nodetool setautorepairconfig min_repair_task_duration 0s
```
4. Now we should not have any soak period between repair tasks. The logs should show a minimal gap in time between 2 repair commands:
```
INFO  [Repair#548:1] 2024-12-20 08:48:25,628 RepairRunnable.java:232 - [repair #3b1c05b0-bef2-11ef-830c-11e11afe1701]Repair command #548 finished in 0 seconds
INFO  [AutoRepair-Repair-full:1] 2024-12-20 08:48:25,628 AutoRepair.java:374 - Repair completed for system_distributed tables [repair_history], range (5764607523034234879,6148914691236517204]
INFO  [AutoRepair-RepairRunnable-full:1] 2024-12-20 08:48:25,628 RepairRunnable.java:327 - Starting repair command #549 (3b3225c0-bef2-11ef-830c-11e11afe1701), repairing keyspace system_distributed with repair options (parallelism: parallel, primary range: true, incremental: false, job threads: 1, ColumnFamilies: [repair_history], dataCenters: [], hosts: [], previewKind: NONE, # of ranges: 1, pull repair: false, force repair: false, optimise streams: true, ignore unreplicated keyspaces: true, repairPaxos: false, paxosOnly: false)
```