### PR TITLE
AutoRepair documentation improvements

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2397,10 +2397,15 @@ storage_compatibility_mode: NONE
 #           # value if the impact of repairs is causing too much load on the cluster or increase it
 #           # if writes outpace the amount of data being repaired. Alternatively, adjust the
 #           # min_repair_interval.
+#           # This is set to a large value for full repair to attempt to repair all data per repair schedule.
 #           max_bytes_per_schedule: 100000GiB
 #     incremental:
 #       enabled: true
-#       # Incremental repairs finish quickly, so they can be run more frequently. The default is 1 hour.
+#       # Incremental repairs operate over unrepaired data and should finish quickly. Running them more frequently keeps
+#       # the unrepaired set smaller and thus causes repairs to operate over a smaller set of data, so a more frequent
+#       # schedule such as 1h is recommended.
+#       # When turning on incremental repair for the first time with a decent amount of data it may be advisable to
+#       # increase this interval to 24h or longer to reduce the impact of anticompaction caused by incremental repair.
 #       min_repair_interval: 1h
 #       token_range_splitter:
 #         parameters:
@@ -2432,6 +2437,7 @@ storage_compatibility_mode: NONE
 #   # The scheduler needs to adjust its order when nodes leave the ring. Deleted hosts are tracked in metadata
 #   # for a specified duration to ensure they are indeed removed before adjustments are made to the schedule.
 #   history_clear_delete_hosts_buffer_interval: 2h
+#   # NOTE: Each of the below settings can be overridden per repair type under repair_type_overrides
 #   global_settings:
 #     # If true, attempts to group tables in the same keyspace into one repair; otherwise, each table is repaired
 #     # individually.
@@ -2444,7 +2450,7 @@ storage_compatibility_mode: NONE
 #     # Percentage of nodes in the cluster running repair in parallel. If parallel_repair_count is set, the larger value
 #     # is used. Recommendation is that the repair cycle on the cluster should finish within gc_grace_seconds.
 #     parallel_repair_percentage: 3
-#     # Repairs materialized view if true.
+#     # Repairs materialized views if true.
 #     materialized_view_repair_enabled: false
 #     # Delay before starting repairs after a node restarts to avoid repairs starting immediately after a restart.
 #     initial_scheduler_delay: 5m
@@ -2466,9 +2472,9 @@ storage_compatibility_mode: NONE
 #     # Repair only the primary ranges owned by a node. Equivalent to the -pr option in nodetool repair. Defaults
 #     # to true. General advice is to keep this true.
 #     repair_primary_token_range_only: true
-#     # Splitter implementation to generate repair assignments. Defaults to RepairTokenRangeSplitter.
-#     token_range_splitter: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
 #     token_range_splitter:
+#       # Splitter implementation to generate repair assignments. Defaults to RepairTokenRangeSplitter.
+#       class_name: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
 #       parameters:
 #         # Target number of partitions to include in a repair assignment to reduce excessive overstreaming.
 #         partitions_per_assignment: 1048576

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2411,7 +2411,7 @@ storage_compatibility_mode: NONE
 #      # Threshold to skip a table if it has too many sstables. The default is 10000. This means, if a table on a node has 10000 or more SSTables, then that table will be skipped.
 #      # This is to avoid penalizing good tables (neighbors) with an outlier.
 #      sstable_upper_threshold: 10000
-#      # Max time for repairing one table on a given node, if exceeded, skip the table. The default is 6 hours.
+#      # Max time for repairing one table on a given node, if exceeded, skip the table.
 #      # Let's say there is a Cassandra cluster in that there are 10 tables belonging to 10 different customers.
 #      # Out of these 10 tables, 1 table is humongous. Repairing this 1 table, say, takes 5 days, in the worst case, but others could finish in just 1 hour.
 #      # Then we would penalize 9 customers just because of one bad actor, and those 9 customers would ping an operator and would require a lot of back-and-forth manual interventions, etc.
@@ -2420,10 +2420,10 @@ storage_compatibility_mode: NONE
 #      # This is useful if you want to completely avoid running repairs in one or more data centers. By default, it is empty, i.e., the framework will repair nodes in all the datacenters.
 #      # If you want to avoid repairing nodes in one or more data centers, then you can specify the data centers in this list.
 #      ignore_dcs: []
-#      # Set this 'true' if AutoRepair should repair only the primary ranges owned by this node; else, 'false'
+#      # Set this 'true' if AutoRepair should repair only the primary ranges owned by this node; else, 'false'.
 #      # It is the same as -pr in nodetool repair options.
 #      repair_primary_token_range_only: true
-#      # The number of nodes running repair parallelly. If parallel_repair_percentage is set, it will choose the larger value of the two. The default is 3.
+#      # The number of nodes running repair parallelly. If parallel_repair_percentage is set, it will choose the larger value of the two.
 #      # This configuration controls how many nodes would run repair in parallel.
 #      # The value “3” means, at any given point in time, at most 3 nodes would be running repair in parallel. These selected nodes can be from any datacenters.
 #      # If one or more node(s) finish repair, then the framework automatically picks up the next candidate(s) based on the least repair time.
@@ -2434,7 +2434,7 @@ storage_compatibility_mode: NONE
 #      # the nodes keep getting added/removed due to elasticity, so if we have a fixed number, then manual interventions would increase because, on a continuous basis,operators would have to adjust to meet the SLA.
 #      # The default is 3%, which means that 3% of the nodes in the Cassandra cluster would be repaired in parallel.
 #      # So now, if a fleet, an operator won't have to worry about changing the repair frequency, etc., as overall repair time will continue to remain the same even if nodes are added or removed due to elasticity.
-#      # Extremely fewer manual interventions as it will rarely violate the repair SLA for customers
+#      # Extremely fewer manual interventions as it will rarely violate the repair SLA for customers.
 #      parallel_repair_percentage: 3
 #      # If the scheduler should repair MV table or not.
 #      mv_repair_enabled: false
@@ -2461,9 +2461,9 @@ storage_compatibility_mode: NONE
 #      # The maximum number of tables that can be included in a repair assignment.
 #      # This aims to reduce the number of repairs, especially in cases where a large amount of tables exists for
 #      # a keyspace.  Note that the splitter will avoid batching tables together if they exceed the other
-#      # configuration paramters such as <code>bytes_per_assignment</code> and <code>partitions_per_assignment</code>
+#      # configuration parameters such as <code>bytes_per_assignment</code> and <code>partitions_per_assignment</code>
 #      token_range_splitter.max_tables_per_assignment: 64
-#      # The maximum number of bytes to cover an individiual schedule.  This serves
+#      # The maximum number of bytes to cover an individual schedule.  This serves
 #      # as a mechanism for throttling the amount of work that can be done on each repair cycle.  One may opt to
 #      # reduce this value if the impact of repairs is causing too many load on the cluster, or increase it if
 #      # writes outpace the amount of data being repaired.  Alternatively, one may want to choose tuning down or up

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2368,3 +2368,104 @@ drop_compact_storage_enabled: false
 #   compatibility mode would no longer toggle behaviors as when it was running in the UPGRADING mode.
 #
 storage_compatibility_mode: NONE
+
+# Configuration for AutoRepair Scheduler
+#auto_repair:
+#  # Enable/Disable auto repair scheduler.
+#  # If it is set to false, then the scheduler thread will not be spun up.
+#  # If it is set to true, then the repair scheduler thread will be created. The thread will
+#  # look for secondary config available for each repair type (full, incremental, and preview_repaired),
+#  # and based on that, it will schedule repairs.
+#  enabled: false
+#  # Time interval between successive checks for repair scheduler to check if either the ongoing repair is completed or if
+#  # none is going, then check if it's time to schedule or wait.
+#  repair_check_interval: 5m
+#  # Maximum number of retries for a repair session.
+#  repair_max_retries: 3
+#  # Backoff time in seconds for retrying a repair session.
+#  repair_retry_backoff: 30s
+#  # Minimum duration for the execution of a single repair task (i.e.: RepairRunnable).
+#  # This helps prevent the auto-repair scheduler from overwhelming the node by scheduling a large number of
+#  # repair tasks in a short period of time.
+#  repair_task_min_duration: 5s
+#  # When any nodes leave the ring then the repair schedule needs to adjust the order, etc.
+#  # The AutoRepair scheduler keeps the deleted hosts information in its persisted metadata for the defined interval in this config.
+#  # This information is useful so the scheduler is absolutely sure that the node is indeed removed from the ring, and then it can adjust the repair schedule accordingly.
+#  # So, the duration in this config determinses for how long deleted host's information is kept in the scheduler's metadata.
+#  history_clear_delete_hosts_buffer_interval: 2h
+#  # Configuration specific to each repair type. Options: full, incremental, and preview_repaired.
+#  repair_type_overrides:
+#    full:
+#      # Enable/Disable full auto repair
+#      enabled: false
+#      # Minimum time in hours between repairing the same node again. This is useful for extremely tiny clusters, say 5 nodes, which finishes
+#      # repair quicly. The default is 24 hours. This means that if the scheduler finishes one round on all the nodes in < 24 hours. On a given node it won’t start a new repair round
+#      # until the last repair conducted on a given node is < 24 hours.
+#      min_repair_interval: 24h
+#      # Repair table by table if this is set to 'false'. If it is 'true', then repair all the tables in a keyspace in one go.
+#      repair_by_keyspace: false
+#      # Number of repair threads to run for a given invoked Repair Job.
+#      # Once the scheduler schedules one repair session, then howmany threads to use inside that job will be controlled through this parameter.
+#      # This is similar to -j for repair options for the nodetool repair command.
+#      number_of_repair_threads: 1
+#      # Threshold to skip a table if it has too many sstables. The default is 10000. This means, if a table on a node has 10000 or more SSTables, then that table will be skipped.
+#      # This is to avoid penalizing good tables (neighbors) with an outlier.
+#      sstable_upper_threshold: 10000
+#      # Max time for repairing one table on a given node, if exceeded, skip the table. The default is 6 hours.
+#      # Let's say there is a Cassandra cluster in that there are 10 tables belonging to 10 different customers.
+#      # Out of these 10 tables, 1 table is humongous. Repairing this 1 table, say, takes 5 days, in the worst case, but others could finish in just 1 hour.
+#      # Then we would penalize 9 customers just because of one bad actor, and those 9 customers would ping an operator and would require a lot of back-and-forth manual interventions, etc.
+#      # So, the idea here is to penalize the outliers instead of good candidates. This can easily be configured with a higher value if we want to disable the functionality.
+#      table_max_repair_time: 6h
+#      # This is useful if you want to completely avoid running repairs in one or more data centers. By default, it is empty, i.e., the framework will repair nodes in all the datacenters.
+#      # If you want to avoid repairing nodes in one or more data centers, then you can specify the data centers in this list.
+#      ignore_dcs: []
+#      # Set this 'true' if AutoRepair should repair only the primary ranges owned by this node; else, 'false'
+#      # It is the same as -pr in nodetool repair options.
+#      repair_primary_token_range_only: true
+#      # The number of nodes running repair parallelly. If parallel_repair_percentage is set, it will choose the larger value of the two. The default is 3.
+#      # This configuration controls how many nodes would run repair in parallel.
+#      # The value “3” means, at any given point in time, at most 3 nodes would be running repair in parallel. These selected nodes can be from any datacenters.
+#      # If one or more node(s) finish repair, then the framework automatically picks up the next candidate(s) based on the least repair time.
+#      # It will ensure the maximum number of nodes running repair do not exceed “3”.
+#      parallel_repair_count: 3
+#      # The percentage of nodes in the cluster that run repair parallelly. If parallel_repair_count is set, it will choose the larger value of the two.
+#      # The problem with a fixed number of nodes (parallel_repair_count property) is that in a large-scale environment,
+#      # the nodes keep getting added/removed due to elasticity, so if we have a fixed number, then manual interventions would increase because, on a continuous basis,operators would have to adjust to meet the SLA.
+#      # The default is 3%, which means that 3% of the nodes in the Cassandra cluster would be repaired in parallel.
+#      # So now, if a fleet, an operator won't have to worry about changing the repair frequency, etc., as overall repair time will continue to remain the same even if nodes are added or removed due to elasticity.
+#      # Extremely fewer manual interventions as it will rarely violate the repair SLA for customers
+#      parallel_repair_percentage: 3
+#      # If the scheduler should repair MV table or not.
+#      mv_repair_enabled: false
+#      # After a node restart, wait for this much delay before scheduler starts running repair; this is to avoid starting repair immediately after a node restart.
+#      initial_scheduler_delay: 5m
+#      # The major issue with Repair is sometimes repair session hangs; so this timeout is useful to resume such stuck repair sessions.
+#      repair_session_timeout: 3h
+#      # Whether to force immediate repair on new nodes. This is useful if you want to repair newly bootstrapped nodes immediately after they join the ring.
+#      force_repair_new_node: false
+#      # Splitter implementation to use for generating repair assignments.
+#      # The default is {@link RepairTokenRangeSplitter}. The class should implement {@link IAutoRepairTokenRangeSplitter}
+#      # and have a constructor accepting ({@link RepairType}, {@link java.util.Map})
+#      token_range_splitter: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
+#      # The target and maximum amount of bytes that should be included in a repair
+#      # assignment. This is meant to scope the amount of work involved in a repair.  For incremental repair, this
+#      # involves the total number of bytes in all SSTables containing unrepaired data involving the ranges being
+#      # repaired, including data that doesn't cover the range.  This is to account for the amount of anticompaction
+#      # that is expected. For all other repair types, this involves the amount of data covering the range being
+#      # repaired.
+#      token_range_splitter.bytes_per_assignment: 200GiB
+#      # The target number of partitions that should be included in a repair
+#      # assignment.  This configuration exists to reduce excessive overstreaming.
+#      token_range_splitter.partitions_per_assignment: 1048576
+#      # The maximum number of tables that can be included in a repair assignment.
+#      # This aims to reduce the number of repairs, especially in cases where a large amount of tables exists for
+#      # a keyspace.  Note that the splitter will avoid batching tables together if they exceed the other
+#      # configuration paramters such as <code>bytes_per_assignment</code> and <code>partitions_per_assignment</code>
+#      token_range_splitter.max_tables_per_assignment: 64
+#      # The maximum number of bytes to cover an individiual schedule.  This serves
+#      # as a mechanism for throttling the amount of work that can be done on each repair cycle.  One may opt to
+#      # reduce this value if the impact of repairs is causing too many load on the cluster, or increase it if
+#      # writes outpace the amount of data being repaired.  Alternatively, one may want to choose tuning down or up
+#      # the <code>min_repair_interval</code>.
+#      token_range_splitter.max_bytes_per_schedule: 100000GiB

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2369,103 +2369,110 @@ drop_compact_storage_enabled: false
 #
 storage_compatibility_mode: NONE
 
-# Configuration for AutoRepair Scheduler
-#auto_repair:
-#  # Enable/Disable auto repair scheduler.
-#  # If it is set to false, then the scheduler thread will not be spun up.
-#  # If it is set to true, then the repair scheduler thread will be created. The thread will
-#  # look for secondary config available for each repair type (full, incremental, and preview_repaired),
-#  # and based on that, it will schedule repairs.
-#  enabled: false
-#  # Time interval between successive checks for repair scheduler to check if either the ongoing repair is completed or if
-#  # none is going, then check if it's time to schedule or wait.
-#  repair_check_interval: 5m
-#  # Maximum number of retries for a repair session.
-#  repair_max_retries: 3
-#  # Backoff time in seconds for retrying a repair session.
-#  repair_retry_backoff: 30s
-#  # Minimum duration for the execution of a single repair task (i.e.: RepairRunnable).
-#  # This helps prevent the auto-repair scheduler from overwhelming the node by scheduling a large number of
-#  # repair tasks in a short period of time.
-#  repair_task_min_duration: 5s
-#  # When any nodes leave the ring then the repair schedule needs to adjust the order, etc.
-#  # The AutoRepair scheduler keeps the deleted hosts information in its persisted metadata for the defined interval in this config.
-#  # This information is useful so the scheduler is absolutely sure that the node is indeed removed from the ring, and then it can adjust the repair schedule accordingly.
-#  # So, the duration in this config determinses for how long deleted host's information is kept in the scheduler's metadata.
-#  history_clear_delete_hosts_buffer_interval: 2h
-#  # Configuration specific to each repair type. Options: full, incremental, and preview_repaired.
-#  repair_type_overrides:
-#    full:
-#      # Enable/Disable full auto repair
-#      enabled: false
-#      # Minimum time in hours between repairing the same node again. This is useful for extremely tiny clusters, say 5 nodes, which finishes
-#      # repair quicly. The default is 24 hours. This means that if the scheduler finishes one round on all the nodes in < 24 hours. On a given node it won’t start a new repair round
-#      # until the last repair conducted on a given node is < 24 hours.
-#      min_repair_interval: 24h
-#      # Repair table by table if this is set to 'false'. If it is 'true', then repair all the tables in a keyspace in one go.
-#      repair_by_keyspace: false
-#      # Number of repair threads to run for a given invoked Repair Job.
-#      # Once the scheduler schedules one repair session, then howmany threads to use inside that job will be controlled through this parameter.
-#      # This is similar to -j for repair options for the nodetool repair command.
-#      number_of_repair_threads: 1
-#      # Threshold to skip a table if it has too many sstables. The default is 10000. This means, if a table on a node has 10000 or more SSTables, then that table will be skipped.
-#      # This is to avoid penalizing good tables (neighbors) with an outlier.
-#      sstable_upper_threshold: 10000
-#      # Max time for repairing one table on a given node, if exceeded, skip the table.
-#      # Let's say there is a Cassandra cluster in that there are 10 tables belonging to 10 different customers.
-#      # Out of these 10 tables, 1 table is humongous. Repairing this 1 table, say, takes 5 days, in the worst case, but others could finish in just 1 hour.
-#      # Then we would penalize 9 customers just because of one bad actor, and those 9 customers would ping an operator and would require a lot of back-and-forth manual interventions, etc.
-#      # So, the idea here is to penalize the outliers instead of good candidates. This can easily be configured with a higher value if we want to disable the functionality.
-#      table_max_repair_time: 6h
-#      # This is useful if you want to completely avoid running repairs in one or more data centers. By default, it is empty, i.e., the framework will repair nodes in all the datacenters.
-#      # If you want to avoid repairing nodes in one or more data centers, then you can specify the data centers in this list.
-#      ignore_dcs: []
-#      # Set this 'true' if AutoRepair should repair only the primary ranges owned by this node; else, 'false'.
-#      # It is the same as -pr in nodetool repair options.
-#      repair_primary_token_range_only: true
-#      # The number of nodes running repair parallelly. If parallel_repair_percentage is set, it will choose the larger value of the two.
-#      # This configuration controls how many nodes would run repair in parallel.
-#      # The value “3” means, at any given point in time, at most 3 nodes would be running repair in parallel. These selected nodes can be from any datacenters.
-#      # If one or more node(s) finish repair, then the framework automatically picks up the next candidate(s) based on the least repair time.
-#      # It will ensure the maximum number of nodes running repair do not exceed “3”.
-#      parallel_repair_count: 3
-#      # The percentage of nodes in the cluster that run repair parallelly. If parallel_repair_count is set, it will choose the larger value of the two.
-#      # The problem with a fixed number of nodes (parallel_repair_count property) is that in a large-scale environment,
-#      # the nodes keep getting added/removed due to elasticity, so if we have a fixed number, then manual interventions would increase because, on a continuous basis,operators would have to adjust to meet the SLA.
-#      # The default is 3%, which means that 3% of the nodes in the Cassandra cluster would be repaired in parallel.
-#      # So now, if a fleet, an operator won't have to worry about changing the repair frequency, etc., as overall repair time will continue to remain the same even if nodes are added or removed due to elasticity.
-#      # Extremely fewer manual interventions as it will rarely violate the repair SLA for customers.
-#      parallel_repair_percentage: 3
-#      # If the scheduler should repair MV table or not.
-#      mv_repair_enabled: false
-#      # After a node restart, wait for this much delay before scheduler starts running repair; this is to avoid starting repair immediately after a node restart.
-#      initial_scheduler_delay: 5m
-#      # The major issue with Repair is sometimes repair session hangs; so this timeout is useful to resume such stuck repair sessions.
-#      repair_session_timeout: 3h
-#      # Whether to force immediate repair on new nodes. This is useful if you want to repair newly bootstrapped nodes immediately after they join the ring.
-#      force_repair_new_node: false
-#      # Splitter implementation to use for generating repair assignments.
-#      # The default is {@link RepairTokenRangeSplitter}. The class should implement {@link IAutoRepairTokenRangeSplitter}
-#      # and have a constructor accepting ({@link RepairType}, {@link java.util.Map})
-#      token_range_splitter: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
-#      # The target and maximum amount of bytes that should be included in a repair
-#      # assignment. This is meant to scope the amount of work involved in a repair.  For incremental repair, this
-#      # involves the total number of bytes in all SSTables containing unrepaired data involving the ranges being
-#      # repaired, including data that doesn't cover the range.  This is to account for the amount of anticompaction
-#      # that is expected. For all other repair types, this involves the amount of data covering the range being
-#      # repaired.
-#      token_range_splitter.bytes_per_assignment: 200GiB
-#      # The target number of partitions that should be included in a repair
-#      # assignment.  This configuration exists to reduce excessive overstreaming.
-#      token_range_splitter.partitions_per_assignment: 1048576
-#      # The maximum number of tables that can be included in a repair assignment.
-#      # This aims to reduce the number of repairs, especially in cases where a large amount of tables exists for
-#      # a keyspace.  Note that the splitter will avoid batching tables together if they exceed the other
-#      # configuration parameters such as <code>bytes_per_assignment</code> and <code>partitions_per_assignment</code>
-#      token_range_splitter.max_tables_per_assignment: 64
-#      # The maximum number of bytes to cover an individual schedule.  This serves
-#      # as a mechanism for throttling the amount of work that can be done on each repair cycle.  One may opt to
-#      # reduce this value if the impact of repairs is causing too many load on the cluster, or increase it if
-#      # writes outpace the amount of data being repaired.  Alternatively, one may want to choose tuning down or up
-#      # the <code>min_repair_interval</code>.
-#      token_range_splitter.max_bytes_per_schedule: 100000GiB
+# Configuration for AutoRepair Scheduler.
+# auto_repair:
+#   # Enable/Disable the auto-repair scheduler.
+#   # If set to false, the scheduler thread will not be started.
+#   # If set to true, the repair scheduler thread will be created. The thread will
+#   # check for secondary configuration available for each repair type (full, incremental,
+#   # and preview_repaired), and based on that, it will schedule repairs.
+#   enabled: true
+#   repair_type_overrides:
+#     full:
+#       # Enable/Disable full auto-repair
+#       enabled: true
+#       # Minimum duration between repairing the same node again. This is useful for tiny clusters, such as
+#       # clusters with 5 nodes that finish repairs quickly. The default is 24 hours. This means that if the scheduler
+#       # completes one round on all nodes in less than 24 hours, it will not start a new repair round on a given node
+#       # until 24 hours have passed since the last repair.
+#       min_repair_interval: 24h
+#       token_range_splitter:
+#         parameters:
+#           # The target and maximum amount of bytes that should be included in a repair
+#           # assignment. This scopes the amount of work involved in a repair and includes
+#           # the data covering the range being repaired.
+#           bytes_per_assignment: 200GiB
+#           # The maximum number of bytes to cover in an individual schedule. This serves as
+#           # a mechanism to throttle the work done in each repair cycle. You may reduce this
+#           # value if the impact of repairs is causing too much load on the cluster or increase it
+#           # if writes outpace the amount of data being repaired. Alternatively, adjust the
+#           # min_repair_interval.
+#           max_bytes_per_schedule: 100000GiB
+#     incremental:
+#       enabled: true
+#       # Incremental repairs finish quickly, so they can be run more frequently. The default is 1 hour.
+#       min_repair_interval: 1h
+#       token_range_splitter:
+#         parameters:
+#           # Configured to attempt repairing 50GiB of data per repair.
+#           # This throttles the amount of incremental repair and anticompaction done per schedule
+#           # after incremental repairs are turned on.
+#           bytes_per_assignment: 50GiB
+#           # The maximum number of bytes to cover in an individual schedule to 100GiB.
+#           # Consider increasing max_bytes_per_schedule if
+#           # more data is written than this limit within the min_repair_interval.
+#           max_bytes_per_schedule: 100GiB
+#     preview_repaired:
+#       enabled: true
+#       min_repair_interval: 24h
+#       token_range_splitter:
+#         parameters:
+#           bytes_per_assignment: 200GiB
+#           max_bytes_per_schedule: 100000GiB
+#   # Time interval between successive checks to see if ongoing repairs are complete or if it is time to schedule
+#   # repairs.
+#   repair_check_interval: 5m
+#   # Maximum number of retries for a repair session.
+#   repair_max_retries: 3
+#   # Backoff time before retrying a repair session.
+#   repair_retry_backoff: 30s
+#   # Minimum duration for the execution of a single repair task. This prevents the scheduler from overwhelming
+#   # the node by scheduling too many repair tasks in a short period of time.
+#   repair_task_min_duration: 5s
+#   # The scheduler needs to adjust its order when nodes leave the ring. Deleted hosts are tracked in metadata
+#   # for a specified duration to ensure they are indeed removed before adjustments are made to the schedule.
+#   history_clear_delete_hosts_buffer_interval: 2h
+#   global_settings:
+#     # If true, attempts to group tables in the same keyspace into one repair; otherwise, each table is repaired
+#     # individually.
+#     repair_by_keyspace: false
+#     # Number of threads to use for each repair job scheduled by the scheduler. Similar to the -j option in nodetool
+#     # repair.
+#     number_of_repair_threads: 1
+#     # Number of nodes running repair in parallel. If parallel_repair_percentage is set, the larger value is used.
+#     parallel_repair_count: 3
+#     # Percentage of nodes in the cluster running repair in parallel. If parallel_repair_count is set, the larger value
+#     # is used. Recommendation is that the repair cycle on the cluster should finish within gc_grace_seconds.
+#     parallel_repair_percentage: 3
+#     # Repairs materialized view if true.
+#     materialized_view_repair_enabled: false
+#     # Delay before starting repairs after a node restarts to avoid repairs starting immediately after a restart.
+#     initial_scheduler_delay: 5m
+#     # Timeout for resuming stuck repair sessions.
+#     repair_session_timeout: 3h
+#     # Force immediate repair on new nodes after they join the ring.
+#     force_repair_new_node: false
+#     # Threshold to skip repairing tables with too many SSTables. Defaults to 10,000 SSTables to avoid penalizing good
+#     # tables.
+#     sstable_upper_threshold: 10000
+#     # Maximum time allowed for repairing one table on a given node. If exceeded, the repair proceeds to the
+#     # next table.
+#     table_max_repair_time: 6h
+#     # Avoid running repairs in specific data centers. By default, repairs run in all data centers. Specify data
+#     # centers to exclude in this list. Note that repair sessions will still consider all replicas from excluded
+#     # data centers. Useful if you have keyspaces that are not replicated in certain data centers, and you want to
+#     # not run repair schedule in certain data centers.
+#     ignore_dcs: []
+#     # Repair only the primary ranges owned by a node. Equivalent to the -pr option in nodetool repair. Defaults
+#     # to true. General advice is to keep this true.
+#     repair_primary_token_range_only: true
+#     # Splitter implementation to generate repair assignments. Defaults to RepairTokenRangeSplitter.
+#     token_range_splitter: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
+#     token_range_splitter:
+#       parameters:
+#         # Target number of partitions to include in a repair assignment to reduce excessive overstreaming.
+#         partitions_per_assignment: 1048576
+#         # Maximum number of tables to include in a repair assignment. This reduces the number of repairs,
+#         # especially in keyspaces with many tables. The splitter avoids batching tables together if they
+#         # exceed other configuration parameters like bytes_per_assignment or partitions_per_assignment.
+#         max_tables_per_assignment: 64

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -2243,103 +2243,110 @@ default_secondary_index_enabled: true
 #
 storage_compatibility_mode: NONE
 
-# Configuration for AutoRepair Scheduler
-#auto_repair:
-#  # Enable/Disable auto repair scheduler.
-#  # If it is set to false, then the scheduler thread will not be spun up.
-#  # If it is set to true, then the repair scheduler thread will be created. The thread will
-#  # look for secondary config available for each repair type (full, incremental, and preview_repaired),
-#  # and based on that, it will schedule repairs.
-#  enabled: false
-#  # Time interval between successive checks for repair scheduler to check if either the ongoing repair is completed or if
-#  # none is going, then check if it's time to schedule or wait.
-#  repair_check_interval: 5m
-#  # Maximum number of retries for a repair session.
-#  repair_max_retries: 3
-#  # Backoff time in seconds for retrying a repair session.
-#  repair_retry_backoff: 30s
-#  # Minimum duration for the execution of a single repair task (i.e.: RepairRunnable).
-#  # This helps prevent the auto-repair scheduler from overwhelming the node by scheduling a large number of
-#  # repair tasks in a short period of time.
-#  repair_task_min_duration: 5s
-#  # When any nodes leave the ring then the repair schedule needs to adjust the order, etc.
-#  # The AutoRepair scheduler keeps the deleted hosts information in its persisted metadata for the defined interval in this config.
-#  # This information is useful so the scheduler is absolutely sure that the node is indeed removed from the ring, and then it can adjust the repair schedule accordingly.
-#  # So, the duration in this config determinses for how long deleted host's information is kept in the scheduler's metadata.
-#  history_clear_delete_hosts_buffer_interval: 2h
-#  # Configuration specific to each repair type. Options: full, incremental, and preview_repaired.
-#  repair_type_overrides:
-#    full:
-#      # Enable/Disable full auto repair
-#      enabled: false
-#      # Minimum time in hours between repairing the same node again. This is useful for extremely tiny clusters, say 5 nodes, which finishes
-#      # repair quicly. The default is 24 hours. This means that if the scheduler finishes one round on all the nodes in < 24 hours. On a given node it won’t start a new repair round
-#      # until the last repair conducted on a given node is < 24 hours.
-#      min_repair_interval: 24h
-#      # Repair table by table if this is set to 'false'. If it is 'true', then repair all the tables in a keyspace in one go.
-#      repair_by_keyspace: false
-#      # Number of repair threads to run for a given invoked Repair Job.
-#      # Once the scheduler schedules one repair session, then howmany threads to use inside that job will be controlled through this parameter.
-#      # This is similar to -j for repair options for the nodetool repair command.
-#      number_of_repair_threads: 1
-#      # Threshold to skip a table if it has too many sstables. The default is 10000. This means, if a table on a node has 10000 or more SSTables, then that table will be skipped.
-#      # This is to avoid penalizing good tables (neighbors) with an outlier.
-#      sstable_upper_threshold: 10000
-#      # Max time for repairing one table on a given node, if exceeded, skip the table.
-#      # Let's say there is a Cassandra cluster in that there are 10 tables belonging to 10 different customers.
-#      # Out of these 10 tables, 1 table is humongous. Repairing this 1 table, say, takes 5 days, in the worst case, but others could finish in just 1 hour.
-#      # Then we would penalize 9 customers just because of one bad actor, and those 9 customers would ping an operator and would require a lot of back-and-forth manual interventions, etc.
-#      # So, the idea here is to penalize the outliers instead of good candidates. This can easily be configured with a higher value if we want to disable the functionality.
-#      table_max_repair_time: 6h
-#      # This is useful if you want to completely avoid running repairs in one or more data centers. By default, it is empty, i.e., the framework will repair nodes in all the datacenters.
-#      # If you want to avoid repairing nodes in one or more data centers, then you can specify the data centers in this list.
-#      ignore_dcs: []
-#      # Set this 'true' if AutoRepair should repair only the primary ranges owned by this node; else, 'false'.
-#      # It is the same as -pr in nodetool repair options.
-#      repair_primary_token_range_only: true
-#      # The number of nodes running repair parallelly. If parallel_repair_percentage is set, it will choose the larger value of the two.
-#      # This configuration controls how many nodes would run repair in parallel.
-#      # The value “3” means, at any given point in time, at most 3 nodes would be running repair in parallel. These selected nodes can be from any datacenters.
-#      # If one or more node(s) finish repair, then the framework automatically picks up the next candidate(s) based on the least repair time.
-#      # It will ensure the maximum number of nodes running repair do not exceed “3”.
-#      parallel_repair_count: 3
-#      # The percentage of nodes in the cluster that run repair parallelly. If parallel_repair_count is set, it will choose the larger value of the two.
-#      # The problem with a fixed number of nodes (parallel_repair_count property) is that in a large-scale environment,
-#      # the nodes keep getting added/removed due to elasticity, so if we have a fixed number, then manual interventions would increase because, on a continuous basis,operators would have to adjust to meet the SLA.
-#      # The default is 3%, which means that 3% of the nodes in the Cassandra cluster would be repaired in parallel.
-#      # So now, if a fleet, an operator won't have to worry about changing the repair frequency, etc., as overall repair time will continue to remain the same even if nodes are added or removed due to elasticity.
-#      # Extremely fewer manual interventions as it will rarely violate the repair SLA for customers.
-#      parallel_repair_percentage: 3
-#      # If the scheduler should repair MV table or not.
-#      mv_repair_enabled: false
-#      # After a node restart, wait for this much delay before scheduler starts running repair; this is to avoid starting repair immediately after a node restart.
-#      initial_scheduler_delay: 5m
-#      # The major issue with Repair is sometimes repair session hangs; so this timeout is useful to resume such stuck repair sessions.
-#      repair_session_timeout: 3h
-#      # Whether to force immediate repair on new nodes. This is useful if you want to repair newly bootstrapped nodes immediately after they join the ring.
-#      force_repair_new_node: false
-#      # Splitter implementation to use for generating repair assignments.
-#      # The default is {@link RepairTokenRangeSplitter}. The class should implement {@link IAutoRepairTokenRangeSplitter}
-#      # and have a constructor accepting ({@link RepairType}, {@link java.util.Map})
-#      token_range_splitter: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
-#      # The target and maximum amount of bytes that should be included in a repair
-#      # assignment. This is meant to scope the amount of work involved in a repair.  For incremental repair, this
-#      # involves the total number of bytes in all SSTables containing unrepaired data involving the ranges being
-#      # repaired, including data that doesn't cover the range.  This is to account for the amount of anticompaction
-#      # that is expected. For all other repair types, this involves the amount of data covering the range being
-#      # repaired.
-#      token_range_splitter.bytes_per_assignment: 200GiB
-#      # The target number of partitions that should be included in a repair
-#      # assignment.  This configuration exists to reduce excessive overstreaming.
-#      token_range_splitter.partitions_per_assignment: 1048576
-#      # The maximum number of tables that can be included in a repair assignment.
-#      # This aims to reduce the number of repairs, especially in cases where a large amount of tables exists for
-#      # a keyspace.  Note that the splitter will avoid batching tables together if they exceed the other
-#      # configuration parameters such as <code>bytes_per_assignment</code> and <code>partitions_per_assignment</code>
-#      token_range_splitter.max_tables_per_assignment: 64
-#      # The maximum number of bytes to cover an individual schedule.  This serves
-#      # as a mechanism for throttling the amount of work that can be done on each repair cycle.  One may opt to
-#      # reduce this value if the impact of repairs is causing too many load on the cluster, or increase it if
-#      # writes outpace the amount of data being repaired.  Alternatively, one may want to choose tuning down or up
-#      # the <code>min_repair_interval</code>.
-#      token_range_splitter.max_bytes_per_schedule: 100000GiB
+# Configuration for AutoRepair Scheduler.
+# auto_repair:
+#   # Enable/Disable the auto-repair scheduler.
+#   # If set to false, the scheduler thread will not be started.
+#   # If set to true, the repair scheduler thread will be created. The thread will
+#   # check for secondary configuration available for each repair type (full, incremental,
+#   # and preview_repaired), and based on that, it will schedule repairs.
+#   enabled: true
+#   repair_type_overrides:
+#     full:
+#       # Enable/Disable full auto-repair
+#       enabled: true
+#       # Minimum duration between repairing the same node again. This is useful for tiny clusters, such as
+#       # clusters with 5 nodes that finish repairs quickly. The default is 24 hours. This means that if the scheduler
+#       # completes one round on all nodes in less than 24 hours, it will not start a new repair round on a given node
+#       # until 24 hours have passed since the last repair.
+#       min_repair_interval: 24h
+#       token_range_splitter:
+#         parameters:
+#           # The target and maximum amount of bytes that should be included in a repair
+#           # assignment. This scopes the amount of work involved in a repair and includes
+#           # the data covering the range being repaired.
+#           bytes_per_assignment: 200GiB
+#           # The maximum number of bytes to cover in an individual schedule. This serves as
+#           # a mechanism to throttle the work done in each repair cycle. You may reduce this
+#           # value if the impact of repairs is causing too much load on the cluster or increase it
+#           # if writes outpace the amount of data being repaired. Alternatively, adjust the
+#           # min_repair_interval.
+#           max_bytes_per_schedule: 100000GiB
+#     incremental:
+#       enabled: true
+#       # Incremental repairs finish quickly, so they can be run more frequently. The default is 1 hour.
+#       min_repair_interval: 1h
+#       token_range_splitter:
+#         parameters:
+#           # Configured to attempt repairing 50GiB of data per repair.
+#           # This throttles the amount of incremental repair and anticompaction done per schedule
+#           # after incremental repairs are turned on.
+#           bytes_per_assignment: 50GiB
+#           # The maximum number of bytes to cover in an individual schedule to 100GiB.
+#           # Consider increasing max_bytes_per_schedule if
+#           # more data is written than this limit within the min_repair_interval.
+#           max_bytes_per_schedule: 100GiB
+#     preview_repaired:
+#       enabled: true
+#       min_repair_interval: 24h
+#       token_range_splitter:
+#         parameters:
+#           bytes_per_assignment: 200GiB
+#           max_bytes_per_schedule: 100000GiB
+#   # Time interval between successive checks to see if ongoing repairs are complete or if it is time to schedule
+#   # repairs.
+#   repair_check_interval: 5m
+#   # Maximum number of retries for a repair session.
+#   repair_max_retries: 3
+#   # Backoff time before retrying a repair session.
+#   repair_retry_backoff: 30s
+#   # Minimum duration for the execution of a single repair task. This prevents the scheduler from overwhelming
+#   # the node by scheduling too many repair tasks in a short period of time.
+#   repair_task_min_duration: 5s
+#   # The scheduler needs to adjust its order when nodes leave the ring. Deleted hosts are tracked in metadata
+#   # for a specified duration to ensure they are indeed removed before adjustments are made to the schedule.
+#   history_clear_delete_hosts_buffer_interval: 2h
+#   global_settings:
+#     # If true, attempts to group tables in the same keyspace into one repair; otherwise, each table is repaired
+#     # individually.
+#     repair_by_keyspace: false
+#     # Number of threads to use for each repair job scheduled by the scheduler. Similar to the -j option in nodetool
+#     # repair.
+#     number_of_repair_threads: 1
+#     # Number of nodes running repair in parallel. If parallel_repair_percentage is set, the larger value is used.
+#     parallel_repair_count: 3
+#     # Percentage of nodes in the cluster running repair in parallel. If parallel_repair_count is set, the larger value
+#     # is used. Recommendation is that the repair cycle on the cluster should finish within gc_grace_seconds.
+#     parallel_repair_percentage: 3
+#     # Repairs materialized view if true.
+#     materialized_view_repair_enabled: false
+#     # Delay before starting repairs after a node restarts to avoid repairs starting immediately after a restart.
+#     initial_scheduler_delay: 5m
+#     # Timeout for resuming stuck repair sessions.
+#     repair_session_timeout: 3h
+#     # Force immediate repair on new nodes after they join the ring.
+#     force_repair_new_node: false
+#     # Threshold to skip repairing tables with too many SSTables. Defaults to 10,000 SSTables to avoid penalizing good
+#     # tables.
+#     sstable_upper_threshold: 10000
+#     # Maximum time allowed for repairing one table on a given node. If exceeded, the repair proceeds to the
+#     # next table.
+#     table_max_repair_time: 6h
+#     # Avoid running repairs in specific data centers. By default, repairs run in all data centers. Specify data
+#     # centers to exclude in this list. Note that repair sessions will still consider all replicas from excluded
+#     # data centers. Useful if you have keyspaces that are not replicated in certain data centers, and you want to
+#     # not run repair schedule in certain data centers.
+#     ignore_dcs: []
+#     # Repair only the primary ranges owned by a node. Equivalent to the -pr option in nodetool repair. Defaults
+#     # to true. General advice is to keep this true.
+#     repair_primary_token_range_only: true
+#     # Splitter implementation to generate repair assignments. Defaults to RepairTokenRangeSplitter.
+#     token_range_splitter: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
+#     token_range_splitter:
+#       parameters:
+#         # Target number of partitions to include in a repair assignment to reduce excessive overstreaming.
+#         partitions_per_assignment: 1048576
+#         # Maximum number of tables to include in a repair assignment. This reduces the number of repairs,
+#         # especially in keyspaces with many tables. The splitter avoids batching tables together if they
+#         # exceed other configuration parameters like bytes_per_assignment or partitions_per_assignment.
+#         max_tables_per_assignment: 64

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -2285,7 +2285,7 @@ storage_compatibility_mode: NONE
 #      # Threshold to skip a table if it has too many sstables. The default is 10000. This means, if a table on a node has 10000 or more SSTables, then that table will be skipped.
 #      # This is to avoid penalizing good tables (neighbors) with an outlier.
 #      sstable_upper_threshold: 10000
-#      # Max time for repairing one table on a given node, if exceeded, skip the table. The default is 6 hours.
+#      # Max time for repairing one table on a given node, if exceeded, skip the table.
 #      # Let's say there is a Cassandra cluster in that there are 10 tables belonging to 10 different customers.
 #      # Out of these 10 tables, 1 table is humongous. Repairing this 1 table, say, takes 5 days, in the worst case, but others could finish in just 1 hour.
 #      # Then we would penalize 9 customers just because of one bad actor, and those 9 customers would ping an operator and would require a lot of back-and-forth manual interventions, etc.
@@ -2294,10 +2294,10 @@ storage_compatibility_mode: NONE
 #      # This is useful if you want to completely avoid running repairs in one or more data centers. By default, it is empty, i.e., the framework will repair nodes in all the datacenters.
 #      # If you want to avoid repairing nodes in one or more data centers, then you can specify the data centers in this list.
 #      ignore_dcs: []
-#      # Set this 'true' if AutoRepair should repair only the primary ranges owned by this node; else, 'false'
+#      # Set this 'true' if AutoRepair should repair only the primary ranges owned by this node; else, 'false'.
 #      # It is the same as -pr in nodetool repair options.
 #      repair_primary_token_range_only: true
-#      # The number of nodes running repair parallelly. If parallel_repair_percentage is set, it will choose the larger value of the two. The default is 3.
+#      # The number of nodes running repair parallelly. If parallel_repair_percentage is set, it will choose the larger value of the two.
 #      # This configuration controls how many nodes would run repair in parallel.
 #      # The value “3” means, at any given point in time, at most 3 nodes would be running repair in parallel. These selected nodes can be from any datacenters.
 #      # If one or more node(s) finish repair, then the framework automatically picks up the next candidate(s) based on the least repair time.
@@ -2308,7 +2308,7 @@ storage_compatibility_mode: NONE
 #      # the nodes keep getting added/removed due to elasticity, so if we have a fixed number, then manual interventions would increase because, on a continuous basis,operators would have to adjust to meet the SLA.
 #      # The default is 3%, which means that 3% of the nodes in the Cassandra cluster would be repaired in parallel.
 #      # So now, if a fleet, an operator won't have to worry about changing the repair frequency, etc., as overall repair time will continue to remain the same even if nodes are added or removed due to elasticity.
-#      # Extremely fewer manual interventions as it will rarely violate the repair SLA for customers
+#      # Extremely fewer manual interventions as it will rarely violate the repair SLA for customers.
 #      parallel_repair_percentage: 3
 #      # If the scheduler should repair MV table or not.
 #      mv_repair_enabled: false
@@ -2335,9 +2335,9 @@ storage_compatibility_mode: NONE
 #      # The maximum number of tables that can be included in a repair assignment.
 #      # This aims to reduce the number of repairs, especially in cases where a large amount of tables exists for
 #      # a keyspace.  Note that the splitter will avoid batching tables together if they exceed the other
-#      # configuration paramters such as <code>bytes_per_assignment</code> and <code>partitions_per_assignment</code>
+#      # configuration parameters such as <code>bytes_per_assignment</code> and <code>partitions_per_assignment</code>
 #      token_range_splitter.max_tables_per_assignment: 64
-#      # The maximum number of bytes to cover an individiual schedule.  This serves
+#      # The maximum number of bytes to cover an individual schedule.  This serves
 #      # as a mechanism for throttling the amount of work that can be done on each repair cycle.  One may opt to
 #      # reduce this value if the impact of repairs is causing too many load on the cluster, or increase it if
 #      # writes outpace the amount of data being repaired.  Alternatively, one may want to choose tuning down or up

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -2271,10 +2271,15 @@ storage_compatibility_mode: NONE
 #           # value if the impact of repairs is causing too much load on the cluster or increase it
 #           # if writes outpace the amount of data being repaired. Alternatively, adjust the
 #           # min_repair_interval.
+#           # This is set to a large value for full repair to attempt to repair all data per repair schedule.
 #           max_bytes_per_schedule: 100000GiB
 #     incremental:
 #       enabled: true
-#       # Incremental repairs finish quickly, so they can be run more frequently. The default is 1 hour.
+#       # Incremental repairs operate over unrepaired data and should finish quickly. Running them more frequently keeps
+#       # the unrepaired set smaller and thus causes repairs to operate over a smaller set of data, so a more frequent
+#       # schedule such as 1h is recommended.
+#       # When turning on incremental repair for the first time with a decent amount of data it may be advisable to
+#       # increase this interval to 24h or longer to reduce the impact of anticompaction caused by incremental repair.
 #       min_repair_interval: 1h
 #       token_range_splitter:
 #         parameters:
@@ -2306,6 +2311,7 @@ storage_compatibility_mode: NONE
 #   # The scheduler needs to adjust its order when nodes leave the ring. Deleted hosts are tracked in metadata
 #   # for a specified duration to ensure they are indeed removed before adjustments are made to the schedule.
 #   history_clear_delete_hosts_buffer_interval: 2h
+#   # NOTE: Each of the below settings can be overridden per repair type under repair_type_overrides
 #   global_settings:
 #     # If true, attempts to group tables in the same keyspace into one repair; otherwise, each table is repaired
 #     # individually.
@@ -2318,7 +2324,7 @@ storage_compatibility_mode: NONE
 #     # Percentage of nodes in the cluster running repair in parallel. If parallel_repair_count is set, the larger value
 #     # is used. Recommendation is that the repair cycle on the cluster should finish within gc_grace_seconds.
 #     parallel_repair_percentage: 3
-#     # Repairs materialized view if true.
+#     # Repairs materialized views if true.
 #     materialized_view_repair_enabled: false
 #     # Delay before starting repairs after a node restarts to avoid repairs starting immediately after a restart.
 #     initial_scheduler_delay: 5m
@@ -2340,9 +2346,9 @@ storage_compatibility_mode: NONE
 #     # Repair only the primary ranges owned by a node. Equivalent to the -pr option in nodetool repair. Defaults
 #     # to true. General advice is to keep this true.
 #     repair_primary_token_range_only: true
-#     # Splitter implementation to generate repair assignments. Defaults to RepairTokenRangeSplitter.
-#     token_range_splitter: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
 #     token_range_splitter:
+#       # Splitter implementation to generate repair assignments. Defaults to RepairTokenRangeSplitter.
+#       class_name: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
 #       parameters:
 #         # Target number of partitions to include in a repair assignment to reduce excessive overstreaming.
 #         partitions_per_assignment: 1048576

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -2242,3 +2242,104 @@ default_secondary_index_enabled: true
 #   compatibility mode would no longer toggle behaviors as when it was running in the UPGRADING mode.
 #
 storage_compatibility_mode: NONE
+
+# Configuration for AutoRepair Scheduler
+#auto_repair:
+#  # Enable/Disable auto repair scheduler.
+#  # If it is set to false, then the scheduler thread will not be spun up.
+#  # If it is set to true, then the repair scheduler thread will be created. The thread will
+#  # look for secondary config available for each repair type (full, incremental, and preview_repaired),
+#  # and based on that, it will schedule repairs.
+#  enabled: false
+#  # Time interval between successive checks for repair scheduler to check if either the ongoing repair is completed or if
+#  # none is going, then check if it's time to schedule or wait.
+#  repair_check_interval: 5m
+#  # Maximum number of retries for a repair session.
+#  repair_max_retries: 3
+#  # Backoff time in seconds for retrying a repair session.
+#  repair_retry_backoff: 30s
+#  # Minimum duration for the execution of a single repair task (i.e.: RepairRunnable).
+#  # This helps prevent the auto-repair scheduler from overwhelming the node by scheduling a large number of
+#  # repair tasks in a short period of time.
+#  repair_task_min_duration: 5s
+#  # When any nodes leave the ring then the repair schedule needs to adjust the order, etc.
+#  # The AutoRepair scheduler keeps the deleted hosts information in its persisted metadata for the defined interval in this config.
+#  # This information is useful so the scheduler is absolutely sure that the node is indeed removed from the ring, and then it can adjust the repair schedule accordingly.
+#  # So, the duration in this config determinses for how long deleted host's information is kept in the scheduler's metadata.
+#  history_clear_delete_hosts_buffer_interval: 2h
+#  # Configuration specific to each repair type. Options: full, incremental, and preview_repaired.
+#  repair_type_overrides:
+#    full:
+#      # Enable/Disable full auto repair
+#      enabled: false
+#      # Minimum time in hours between repairing the same node again. This is useful for extremely tiny clusters, say 5 nodes, which finishes
+#      # repair quicly. The default is 24 hours. This means that if the scheduler finishes one round on all the nodes in < 24 hours. On a given node it won’t start a new repair round
+#      # until the last repair conducted on a given node is < 24 hours.
+#      min_repair_interval: 24h
+#      # Repair table by table if this is set to 'false'. If it is 'true', then repair all the tables in a keyspace in one go.
+#      repair_by_keyspace: false
+#      # Number of repair threads to run for a given invoked Repair Job.
+#      # Once the scheduler schedules one repair session, then howmany threads to use inside that job will be controlled through this parameter.
+#      # This is similar to -j for repair options for the nodetool repair command.
+#      number_of_repair_threads: 1
+#      # Threshold to skip a table if it has too many sstables. The default is 10000. This means, if a table on a node has 10000 or more SSTables, then that table will be skipped.
+#      # This is to avoid penalizing good tables (neighbors) with an outlier.
+#      sstable_upper_threshold: 10000
+#      # Max time for repairing one table on a given node, if exceeded, skip the table. The default is 6 hours.
+#      # Let's say there is a Cassandra cluster in that there are 10 tables belonging to 10 different customers.
+#      # Out of these 10 tables, 1 table is humongous. Repairing this 1 table, say, takes 5 days, in the worst case, but others could finish in just 1 hour.
+#      # Then we would penalize 9 customers just because of one bad actor, and those 9 customers would ping an operator and would require a lot of back-and-forth manual interventions, etc.
+#      # So, the idea here is to penalize the outliers instead of good candidates. This can easily be configured with a higher value if we want to disable the functionality.
+#      table_max_repair_time: 6h
+#      # This is useful if you want to completely avoid running repairs in one or more data centers. By default, it is empty, i.e., the framework will repair nodes in all the datacenters.
+#      # If you want to avoid repairing nodes in one or more data centers, then you can specify the data centers in this list.
+#      ignore_dcs: []
+#      # Set this 'true' if AutoRepair should repair only the primary ranges owned by this node; else, 'false'
+#      # It is the same as -pr in nodetool repair options.
+#      repair_primary_token_range_only: true
+#      # The number of nodes running repair parallelly. If parallel_repair_percentage is set, it will choose the larger value of the two. The default is 3.
+#      # This configuration controls how many nodes would run repair in parallel.
+#      # The value “3” means, at any given point in time, at most 3 nodes would be running repair in parallel. These selected nodes can be from any datacenters.
+#      # If one or more node(s) finish repair, then the framework automatically picks up the next candidate(s) based on the least repair time.
+#      # It will ensure the maximum number of nodes running repair do not exceed “3”.
+#      parallel_repair_count: 3
+#      # The percentage of nodes in the cluster that run repair parallelly. If parallel_repair_count is set, it will choose the larger value of the two.
+#      # The problem with a fixed number of nodes (parallel_repair_count property) is that in a large-scale environment,
+#      # the nodes keep getting added/removed due to elasticity, so if we have a fixed number, then manual interventions would increase because, on a continuous basis,operators would have to adjust to meet the SLA.
+#      # The default is 3%, which means that 3% of the nodes in the Cassandra cluster would be repaired in parallel.
+#      # So now, if a fleet, an operator won't have to worry about changing the repair frequency, etc., as overall repair time will continue to remain the same even if nodes are added or removed due to elasticity.
+#      # Extremely fewer manual interventions as it will rarely violate the repair SLA for customers
+#      parallel_repair_percentage: 3
+#      # If the scheduler should repair MV table or not.
+#      mv_repair_enabled: false
+#      # After a node restart, wait for this much delay before scheduler starts running repair; this is to avoid starting repair immediately after a node restart.
+#      initial_scheduler_delay: 5m
+#      # The major issue with Repair is sometimes repair session hangs; so this timeout is useful to resume such stuck repair sessions.
+#      repair_session_timeout: 3h
+#      # Whether to force immediate repair on new nodes. This is useful if you want to repair newly bootstrapped nodes immediately after they join the ring.
+#      force_repair_new_node: false
+#      # Splitter implementation to use for generating repair assignments.
+#      # The default is {@link RepairTokenRangeSplitter}. The class should implement {@link IAutoRepairTokenRangeSplitter}
+#      # and have a constructor accepting ({@link RepairType}, {@link java.util.Map})
+#      token_range_splitter: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
+#      # The target and maximum amount of bytes that should be included in a repair
+#      # assignment. This is meant to scope the amount of work involved in a repair.  For incremental repair, this
+#      # involves the total number of bytes in all SSTables containing unrepaired data involving the ranges being
+#      # repaired, including data that doesn't cover the range.  This is to account for the amount of anticompaction
+#      # that is expected. For all other repair types, this involves the amount of data covering the range being
+#      # repaired.
+#      token_range_splitter.bytes_per_assignment: 200GiB
+#      # The target number of partitions that should be included in a repair
+#      # assignment.  This configuration exists to reduce excessive overstreaming.
+#      token_range_splitter.partitions_per_assignment: 1048576
+#      # The maximum number of tables that can be included in a repair assignment.
+#      # This aims to reduce the number of repairs, especially in cases where a large amount of tables exists for
+#      # a keyspace.  Note that the splitter will avoid batching tables together if they exceed the other
+#      # configuration paramters such as <code>bytes_per_assignment</code> and <code>partitions_per_assignment</code>
+#      token_range_splitter.max_tables_per_assignment: 64
+#      # The maximum number of bytes to cover an individiual schedule.  This serves
+#      # as a mechanism for throttling the amount of work that can be done on each repair cycle.  One may opt to
+#      # reduce this value if the impact of repairs is causing too many load on the cluster, or increase it if
+#      # writes outpace the amount of data being repaired.  Alternatively, one may want to choose tuning down or up
+#      # the <code>min_repair_interval</code>.
+#      token_range_splitter.max_bytes_per_schedule: 100000GiB

--- a/doc/modules/cassandra/pages/auto-repair/overview.adoc
+++ b/doc/modules/cassandra/pages/auto-repair/overview.adoc
@@ -73,7 +73,7 @@ larger value is used.
 | parallel_repair_percentage | 3 | Percentage of nodes in the cluster running repair in parallel. If
 parallel_repair_count is set, the larger value is used. Recommendation is that the repair cycle on the cluster should
 finish within gc_grace_seconds.
-| materialized_view_repair_enabled | false | Repairs materialized view if true.
+| materialized_view_repair_enabled | false | Repairs materialized views if true.
 | initial_scheduler_delay | 5m | Delay before starting repairs after a node restarts to avoid repairs starting
 immediately after a restart.
 | repair_session_timeout | 3h | Timeout for resuming stuck repair sessions.
@@ -111,15 +111,19 @@ being repaired.
 | token_range_splitter.max_bytes_per_schedule | 100000GiB | The maximum number of bytes to cover in an individual
 schedule. This serves as a mechanism to throttle the work done in each repair cycle. You may reduce this value if the
 impact of repairs is causing too much load on the cluster or increase it if writes outpace the amount of data being
-repaired. Alternatively, adjust the min_repair_interval.
+repaired. Alternatively, adjust the min_repair_interval. This is set to a large value for full repair to attempt to
+repair all data per repair schedule.
 |===
 
 ==== Incremental repair level settings
 The following settings can be customized for each repair type.
 [cols=",,",options="header",]
 |===
-| min_repair_interval | 1h | Incremental repairs finish quickly, so they can be run more frequently. The default is
-1 hour.
+| min_repair_interval | 1h | Incremental repairs operate over unrepaired data and should finish quickly. Running them
+more frequently keeps the unrepaired set smaller and thus causes repairs to operate over a smaller set of data,
+so a more frequent schedule such as 1h is recommended. When turning on incremental repair for the first time with a
+decent amount of data it may be advisable to increase this interval to 24h or longer to reduce the impact of
+anticompaction caused by incremental repair.
 | token_range_splitter.bytes_per_assignment | 50GiB | Configured to attempt repairing 50GiB of data per repair.
 This throttles the amount of incremental repair and anticompaction done per schedule after incremental repairs are
 turned on.

--- a/doc/modules/cassandra/pages/auto-repair/overview.adoc
+++ b/doc/modules/cassandra/pages/auto-repair/overview.adoc
@@ -3,47 +3,129 @@
 :description: Auto Repair concepts - How it works, how to configure it, and more.
 :keywords: CEP-37
 
-Repair orchestration inside Apache Cassandra. This fully Automated Repair scheduler inside Cassandra does not depend on the control plane, significantly reducing our operational overhead.
-At a high level, a dedicated thread pool is assigned to the repair scheduler. The repair scheduler inside Cassandra maintains a new replicated table under a distributed system_distributed keyspace. This table maintains the repair history for all the nodes, such as when it was repaired the last time, etc. The scheduler will pick the node(s) that run the repair first and continue orchestration to ensure Every table and all of their token ranges are repaired. The algorithm can also run repairs simultaneously on multiple nodes and splits the token range into subranges with the necessary retry to handle transient failures. The automatic repair runs as soon as we start a Cassandra cluster, like Compaction, and does not require human-in-the-loop.
-The scheduler supports Full, Incremental, and Preview repair types today with the following features. A new repair type, such as Paxos repair and any future repair types, should be extended with minimal dev work!
+Auto Repair is a fully automated scheduler that provides repair orchestration within Apache Cassandra. This
+significantly reduces operational overhead by eliminating the need for operators to deploy external tools to submit and
+manage repairs.
+
+At a high level, a dedicated thread pool is assigned to the repair scheduler. The repair scheduler in Cassandra
+maintains a new replicated table, system_distributed.auto_repair_history, which stores the repair history for all nodes,
+including details such as the last repair time. The scheduler selects the node(s) to begin repairs and orchestrates the
+process to ensure that every table and its token ranges are repaired. The algorithm can run repairs simultaneously on
+multiple nodes and splits token ranges into subranges, with necessary retries to handle transient failures. Automatic
+repair starts as soon as a Cassandra cluster is launched, similar to compaction, and does not require human
+intervention.
+
+The scheduler currently supports Full, Incremental, and Preview repair types with the following features. New repair
+types, such as Paxos repair or other future repair mechanisms, can be integrated with minimal development effort!
+
 
 === Features
-- Capability to run on multiple nodes simultaneously
-- Default implementation and an interface to override the data set being repaired per repair session
-- Ability to extend the token split algorithms with the following two implementations readily available:
-- Splits token ranges by putting a max cap on the size of data being repaired as part of one repair session as well as a max cap at a table level - this is crucial for Incremental Repair (Default)
-- Split tokens evenly based on the number of splits specified
-- A new CQL table property to do the following:
-- Disable repair type at a table level if one wants the scheduler to skip one or more tables
-- Setting repair priority for certain tables to prioritize those tables over others
-- Enabling/Disabling scheduler for each repair type dynamically
-- Per Data Center per job configuration
-- Rich Configuration for each repair type, e.g., full, incremental, or preview_repair
-- Enough observability so an operator can configure alarms depending on their need
+- Capability to run repairs on multiple nodes simultaneously.
+- A default implementation and an interface to override the dataset being repaired per session.
+- Extendable token split algorithms with two implementations readily available:
+.  Splits token ranges by placing a cap on the size of data repaired in one session and a maximum cap at the schedule
+level (default).
+.  Splits tokens evenly based on the specified number of splits.
+- A new CQL table property offering:
+.  The ability to disable specific repair types at the table level, allowing the scheduler to skip one or more tables.
+.  Configuring repair priorities for certain tables to prioritize them over others.
+- Dynamic enablement or disablement of the scheduler for each repair type.
+- Configurable settings tailored to each repair job.
+- Rich configuration options for each repair type (e.g., Full, Incremental, or Preview repairs).
+- Comprehensive observability features that allow operators to configure alarms as needed.
 
 === Yaml Configuration
+
+==== Top level settings
+The following settings are defined at the top level of the configuration file and apply universally across all
+repair types.
+
 [cols=",,",options="header",]
 |===
 | Name | Default | Description
-| enabled | false | Enable/Disable auto repair scheduler
-| min_repair_interval | 24h | Minimum time in hours between repairing the same node again. This is useful for extremely tiny clusters, say 5 nodes, which finishes. repair quicly. The default is 24 hours. This means that if the scheduler finishes one round on all the nodes in < 24 hours. On a given node it won’t start a new repair round until the last repair conducted on a given node is < 24 hours.
-| repair_by_keyspace | false | Repair table by table if this is set to 'false'. If it is 'true', then repair all the tables in a keyspace in one go.
-| number_of_repair_threads | 1 | Number of repair threads to run for a given invoked Repair Job. Once the scheduler schedules one repair session, then howmany threads to use inside that job will be controlled through this parameter. This is similar to -j for repair options for the nodetool repair command.
-| sstable_upper_threshold | 10000 | Threshold to skip a table if it has too many sstables. The default is 10000. This means, if a table on a node has 10000 or more SSTables, then that table will be skipped. This is to avoid penalizing good tables (neighbors) with an outlier.
-| table_max_repair_time | 6h | Max time for repairing one table on a given node, if exceeded, skip the table. Let's say there is a Cassandra cluster in that there are 10 tables belonging to 10 different customers. Out of these 10 tables, 1 table is humongous. Repairing this 1 table, say, takes 5 days, in the worst case, but others could finish in just 1 hour. Then we would penalize 9 customers just because of one bad actor, and those 9 customers would ping an operator and would require a lot of back-and-forth manual interventions, etc. So, the idea here is to penalize the outliers instead of good candidates. This can easily be configured with a higher value if we want to disable the functionality.
-| ignore_dcs | [] | This is useful if you want to completely avoid running repairs in one or more data centers. By default, it is empty, i.e., the framework will repair nodes in all the datacenters. If you want to avoid repairing nodes in one or more data centers, then you can specify the data centers in this list.
-| repair_primary_token_range_only | true | Set this 'true' if AutoRepair should repair only the primary ranges owned by this node; else, 'false'. It is the same as -pr in nodetool repair options.
-| parallel_repair_count | 3 | The number of nodes running repair parallelly. If parallel_repair_percentage is set, it will choose the larger value of the two. This configuration controls how many nodes would run repair in parallel. The value “3” means, at any given point in time, at most 3 nodes would be running repair in parallel. These selected nodes can be from any datacenters. If one or more node(s) finish repair, then the framework automatically picks up the next candidate(s) based on the least repair time. It will ensure the maximum number of nodes running repair do not exceed “3”.
-| parallel_repair_percentage | 3 | The percentage of nodes in the cluster that run repair parallelly. If parallel_repair_count is set, it will choose the larger value of the two. The problem with a fixed number of nodes (parallel_repair_count property) is that in a large-scale environment,the nodes keep getting added/removed due to elasticity, so if we have a fixed number, then manual interventions would increase because, on a continuous basis,operators would have to adjust to meet the SLA. The default is 3%, which means that 3% of the nodes in the Cassandra cluster would be repaired in parallel. So now, if a fleet, an operator won't have to worry about changing the repair frequency, etc., as overall repair time will continue to remain the same even if nodes are added or removed due to elasticity. Extremely fewer manual interventions as it will rarely violate the repair SLA for customers.
-| mv_repair_enabled | false | If the scheduler should repair MV table or not.
-| initial_scheduler_delay | 5m | After a node restart, wait for this much delay before scheduler starts running repair; this is to avoid starting repair immediately after a node restart.
-| repair_session_timeout | 3h | The major issue with Repair is sometimes repair session hangs; so this timeout is useful to resume such stuck repair sessions.
-| force_repair_new_node | false | Whether to force immediate repair on new nodes. This is useful if you want to repair newly bootstrapped nodes immediately after they join the ring.
-| token_range_splitter | org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter | Splitter implementation to use for generating repair assignments.The default is {@link RepairTokenRangeSplitter}. The class should implement {@link IAutoRepairTokenRangeSplitter} and have a constructor accepting ({@link RepairType}, {@link java.util.Map})
-| token_range_splitter.bytes_per_assignment | 200GiB |The target and maximum amount of bytes that should be included in a repair assignment. This is meant to scope the amount of work involved in a repair.  For incremental repair, this involves the total number of bytes in all SSTables containing unrepaired data involving the ranges being repaired, including data that doesn't cover the range.  This is to account for the amount of anticompaction that is expected. For all other repair types, this involves the amount of data covering the range being repaired.
-| token_range_splitter.partitions_per_assignment | 1048576 | he target number of partitions that should be included in a repair assignment.  This configuration exists to reduce excessive overstreaming.
-| token_range_splitter.max_tables_per_assignment | 64 | The maximum number of tables that can be included in a repair assignment. This aims to reduce the number of repairs, especially in cases where a large amount of tables exists for a keyspace.  Note that the splitter will avoid batching tables together if they exceed the other configuration parameters such as <code>bytes_per_assignment</code> and <code>partitions_per_assignment</code>
-| token_range_splitter.max_bytes_per_schedule | 100000GiB | The maximum number of bytes to cover an individual schedule.  This serves as a mechanism for throttling the amount of work that can be done on each repair cycle.  One may opt to reduce this value if the impact of repairs is causing too many load on the cluster, or increase it if writes outpace the amount of data being repaired.  Alternatively, one may want to choose tuning down or up the <code>min_repair_interval</code>.
+| enabled | false | Enable/Disable the auto-repair scheduler. If set to false, the scheduler thread will not be started.
+If set to true, the repair scheduler thread will be created. The thread will check for secondary configuration available
+for each repair type (full, incremental, and preview_repaired), and based on that, it will schedule repairs.
+| repair_check_interval | 5m | Time interval between successive checks to see if ongoing repairs are complete or if it
+is time to schedule repairs.
+| repair_max_retries | 3 | Maximum number of retries for a repair session.
+| repair_retry_backoff | 30s | Backoff time before retrying a repair session.
+| repair_task_min_duration | 5s | Minimum duration for the execution of a single repair task. This prevents the
+scheduler from overwhelming the node by scheduling too many repair tasks in a short period of time.
+| history_clear_delete_hosts_buffer_interval | 2h | The scheduler needs to adjust its order when nodes leave the ring.
+Deleted hosts are tracked in metadata. for a specified duration to ensure they are indeed removed before adjustments
+are made to the schedule.
+|===
+
+
+==== Repair level settings
+The following settings can be tailored individually for each repair type.
+[cols=",,",options="header",]
+|===
+| Name | Default | Description
+| enabled | false | Enable/Disable full/incremental/preview_repaired auto-repair
+| repair_by_keyspace | false | If true, attempts to group tables in the same keyspace into one repair; otherwise,
+each table is repaired individually.
+| number_of_repair_threads | 1 | Number of threads to use for each repair job scheduled by the scheduler. Similar to
+the -j option in nodetool repair.
+| parallel_repair_count | 3 | Number of nodes running repair in parallel. If parallel_repair_percentage is set, the
+larger value is used.
+| parallel_repair_percentage | 3 | Percentage of nodes in the cluster running repair in parallel. If
+parallel_repair_count is set, the larger value is used. Recommendation is that the repair cycle on the cluster should
+finish within gc_grace_seconds.
+| materialized_view_repair_enabled | false | Repairs materialized view if true.
+| initial_scheduler_delay | 5m | Delay before starting repairs after a node restarts to avoid repairs starting
+immediately after a restart.
+| repair_session_timeout | 3h | Timeout for resuming stuck repair sessions.
+| force_repair_new_node | false | Force immediate repair on new nodes after they join the ring.
+| sstable_upper_threshold | 10000 | Threshold to skip repairing tables with too many SSTables. Defaults to 10,000
+SSTables to avoid penalizing good tables.
+| table_max_repair_time | 6h | Maximum time allowed for repairing one table on a given node. If exceeded, the repair
+proceeds to the next table.
+| ignore_dcs | [] | Avoid running repairs in specific data centers. By default, repairs run in all data centers. Specify
+data centers to exclude in this list. Note that repair sessions will still consider all replicas from excluded data
+centers. Useful if you have keyspaces that are not replicated in certain data centers, and you want to not run repair
+schedule in certain data centers.
+| repair_primary_token_range_only | true | Repair only the primary ranges owned by a node. Equivalent to the -pr option
+in nodetool repair. Defaults to true. General advice is to keep this true.
+| token_range_splitter | org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter | Splitter implementation to
+generate repair assignments. Defaults to RepairTokenRangeSplitter.
+| token_range_splitter.partitions_per_assignment | 1048576 | Target number of partitions to include in a repair
+assignment to reduce excessive overstreaming.
+| token_range_splitter.max_tables_per_assignment | 64 | Maximum number of tables to include in a repair assignment.
+This reduces the number of repairs, especially in keyspaces with many tables. The splitter avoids batching tables
+together if they exceed other configuration parameters like bytes_per_assignment or partitions_per_assignment.
+|===
+
+==== Full & Preview_Repaired repair level settings
+The following settings can be tailored individually for each repair type.
+[cols=",,",options="header",]
+|===
+| min_repair_interval | 24h | Minimum duration between repairing the same node again. This is useful for tiny clusters,
+such as clusters with 5 nodes that finish repairs quickly. The default is 24 hours. This means that if the scheduler
+completes one round on all nodes in less than 24 hours, it will not start a new repair round on a given node until 24
+hours have passed since the last repair.
+| token_range_splitter.bytes_per_assignment | 200GiB | The target and maximum amount of bytes that should be included
+in a repair assignment. This scopes the amount of work involved in a repair and includes the data covering the range
+being repaired.
+| token_range_splitter.max_bytes_per_schedule | 100000GiB | The maximum number of bytes to cover in an individual
+schedule. This serves as a mechanism to throttle the work done in each repair cycle. You may reduce this value if the
+impact of repairs is causing too much load on the cluster or increase it if writes outpace the amount of data being
+repaired. Alternatively, adjust the min_repair_interval.
+|===
+
+==== Incremental repair level settings
+The following settings can be customized for each repair type.
+[cols=",,",options="header",]
+|===
+| min_repair_interval | 1h | Incremental repairs finish quickly, so they can be run more frequently. The default is
+1 hour.
+| token_range_splitter.bytes_per_assignment | 50GiB | Configured to attempt repairing 50GiB of data per repair.
+This throttles the amount of incremental repair and anticompaction done per schedule after incremental repairs are
+turned on.
+| token_range_splitter.max_bytes_per_schedule | 100GiB | The maximum number of bytes to cover in an individual schedule
+to 100GiB. Consider increasing max_bytes_per_schedule if more data is written than this limit within
+the min_repair_interval.
 |===
 
 
@@ -68,7 +150,7 @@ configuration for repair_type: full
 	repair_primary_token_range_only: true
 	parallel_repair_count: 3
 	parallel_repair_percentage: 3
-	mv_repair_enabled: false
+	materialized_view_repair_enabled: false
 	initial_scheduler_delay: 5m
 	repair_session_timeout: 3h
 	force_repair_new_node: false
@@ -79,7 +161,7 @@ configuration for repair_type: full
 	token_range_splitter.max_bytes_per_schedule: 100000GiB
 configuration for repair_type: incremental
 	enabled: true
-	min_repair_interval: 24h
+	min_repair_interval: 1h
 	repair_by_keyspace: false
 	number_of_repair_threads: 1
 	sstable_upper_threshold: 10000
@@ -88,7 +170,7 @@ configuration for repair_type: incremental
 	repair_primary_token_range_only: true
 	parallel_repair_count: 3
 	parallel_repair_percentage: 3
-	mv_repair_enabled: false
+	materialized_view_repair_enabled: false
 	initial_scheduler_delay: 5m
 	repair_session_timeout: 3h
 	force_repair_new_node: false
@@ -122,4 +204,4 @@ $> nodetool setautorepairconfig -t incremental number_of_repair_threads 2
 
 
 ==== More details
-https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-37+Apache+Cassandra+Automated+Repair+Solution[CEP-37]
+https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-37+Apache+Cassandra+Unified+Repair+Solution[CEP-37]

--- a/doc/modules/cassandra/pages/auto-repair/overview.adoc
+++ b/doc/modules/cassandra/pages/auto-repair/overview.adoc
@@ -1,0 +1,125 @@
+= Overview of Auto Repair
+:navtitle: Auto Repair overview
+:description: Auto Repair concepts - How it works, how to configure it, and more.
+:keywords: CEP-37
+
+Repair orchestration inside Apache Cassandra. This fully Automated Repair scheduler inside Cassandra does not depend on the control plane, significantly reducing our operational overhead.
+At a high level, a dedicated thread pool is assigned to the repair scheduler. The repair scheduler inside Cassandra maintains a new replicated table under a distributed system_distributed keyspace. This table maintains the repair history for all the nodes, such as when it was repaired the last time, etc. The scheduler will pick the node(s) that run the repair first and continue orchestration to ensure Every table and all of their token ranges are repaired. The algorithm can also run repairs simultaneously on multiple nodes and splits the token range into subranges with the necessary retry to handle transient failures. The automatic repair runs as soon as we start a Cassandra cluster, like Compaction, and does not require human-in-the-loop.
+The scheduler supports Full, Incremental, and Preview repair types today with the following features. A new repair type, such as Paxos repair and any future repair types, should be extended with minimal dev work!
+
+=== Features
+- Capability to run on multiple nodes simultaneously
+- Default implementation and an interface to override the data set being repaired per repair session
+- Ability to extend the token split algorithms with the following two implementations readily available:
+- Splits token ranges by putting a max cap on the size of data being repaired as part of one repair session as well as a max cap at a table level - this is crucial for Incremental Repair (Default)
+- Split tokens evenly based on the number of splits specified
+- A new CQL table property to do the following:
+- Disable repair type at a table level if one wants the scheduler to skip one or more tables
+- Setting repair priority for certain tables to prioritize those tables over others
+- Enabling/Disabling scheduler for each repair type dynamically
+- Per Data Center per job configuration
+- Rich Configuration for each repair type, e.g., full, incremental, or preview_repair
+- Enough observability so an operator can configure alarms depending on their need
+
+=== Yaml Configuration
+[cols=",,",options="header",]
+|===
+| Name | Default | Description
+| enabled | false | Enable/Disable auto repair scheduler
+| min_repair_interval | 24h | Minimum time in hours between repairing the same node again. This is useful for extremely tiny clusters, say 5 nodes, which finishes. repair quicly. The default is 24 hours. This means that if the scheduler finishes one round on all the nodes in < 24 hours. On a given node it won’t start a new repair round until the last repair conducted on a given node is < 24 hours.
+| repair_by_keyspace | false | Repair table by table if this is set to 'false'. If it is 'true', then repair all the tables in a keyspace in one go.
+| number_of_repair_threads | 1 | Number of repair threads to run for a given invoked Repair Job. Once the scheduler schedules one repair session, then howmany threads to use inside that job will be controlled through this parameter. This is similar to -j for repair options for the nodetool repair command.
+| sstable_upper_threshold | 10000 | Threshold to skip a table if it has too many sstables. The default is 10000. This means, if a table on a node has 10000 or more SSTables, then that table will be skipped. This is to avoid penalizing good tables (neighbors) with an outlier.
+| table_max_repair_time | 6h | Max time for repairing one table on a given node, if exceeded, skip the table. Let's say there is a Cassandra cluster in that there are 10 tables belonging to 10 different customers. Out of these 10 tables, 1 table is humongous. Repairing this 1 table, say, takes 5 days, in the worst case, but others could finish in just 1 hour. Then we would penalize 9 customers just because of one bad actor, and those 9 customers would ping an operator and would require a lot of back-and-forth manual interventions, etc. So, the idea here is to penalize the outliers instead of good candidates. This can easily be configured with a higher value if we want to disable the functionality.
+| ignore_dcs | [] | This is useful if you want to completely avoid running repairs in one or more data centers. By default, it is empty, i.e., the framework will repair nodes in all the datacenters. If you want to avoid repairing nodes in one or more data centers, then you can specify the data centers in this list.
+| repair_primary_token_range_only | true | Set this 'true' if AutoRepair should repair only the primary ranges owned by this node; else, 'false'. It is the same as -pr in nodetool repair options.
+| parallel_repair_count | 3 | The number of nodes running repair parallelly. If parallel_repair_percentage is set, it will choose the larger value of the two. This configuration controls how many nodes would run repair in parallel. The value “3” means, at any given point in time, at most 3 nodes would be running repair in parallel. These selected nodes can be from any datacenters. If one or more node(s) finish repair, then the framework automatically picks up the next candidate(s) based on the least repair time. It will ensure the maximum number of nodes running repair do not exceed “3”.
+| parallel_repair_percentage | 3 | The percentage of nodes in the cluster that run repair parallelly. If parallel_repair_count is set, it will choose the larger value of the two. The problem with a fixed number of nodes (parallel_repair_count property) is that in a large-scale environment,the nodes keep getting added/removed due to elasticity, so if we have a fixed number, then manual interventions would increase because, on a continuous basis,operators would have to adjust to meet the SLA. The default is 3%, which means that 3% of the nodes in the Cassandra cluster would be repaired in parallel. So now, if a fleet, an operator won't have to worry about changing the repair frequency, etc., as overall repair time will continue to remain the same even if nodes are added or removed due to elasticity. Extremely fewer manual interventions as it will rarely violate the repair SLA for customers.
+| mv_repair_enabled | false | If the scheduler should repair MV table or not.
+| initial_scheduler_delay | 5m | After a node restart, wait for this much delay before scheduler starts running repair; this is to avoid starting repair immediately after a node restart.
+| repair_session_timeout | 3h | The major issue with Repair is sometimes repair session hangs; so this timeout is useful to resume such stuck repair sessions.
+| force_repair_new_node | false | Whether to force immediate repair on new nodes. This is useful if you want to repair newly bootstrapped nodes immediately after they join the ring.
+| token_range_splitter | org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter | Splitter implementation to use for generating repair assignments.The default is {@link RepairTokenRangeSplitter}. The class should implement {@link IAutoRepairTokenRangeSplitter} and have a constructor accepting ({@link RepairType}, {@link java.util.Map})
+| token_range_splitter.bytes_per_assignment | 200GiB |The target and maximum amount of bytes that should be included in a repair assignment. This is meant to scope the amount of work involved in a repair.  For incremental repair, this involves the total number of bytes in all SSTables containing unrepaired data involving the ranges being repaired, including data that doesn't cover the range.  This is to account for the amount of anticompaction that is expected. For all other repair types, this involves the amount of data covering the range being repaired.
+| token_range_splitter.partitions_per_assignment | 1048576 | he target number of partitions that should be included in a repair assignment.  This configuration exists to reduce excessive overstreaming.
+| token_range_splitter.max_tables_per_assignment | 64 | The maximum number of tables that can be included in a repair assignment. This aims to reduce the number of repairs, especially in cases where a large amount of tables exists for a keyspace.  Note that the splitter will avoid batching tables together if they exceed the other configuration parameters such as <code>bytes_per_assignment</code> and <code>partitions_per_assignment</code>
+| token_range_splitter.max_bytes_per_schedule | 100000GiB | The maximum number of bytes to cover an individual schedule.  This serves as a mechanism for throttling the amount of work that can be done on each repair cycle.  One may opt to reduce this value if the impact of repairs is causing too many load on the cluster, or increase it if writes outpace the amount of data being repaired.  Alternatively, one may want to choose tuning down or up the <code>min_repair_interval</code>.
+|===
+
+
+=== Nodetool Configuration
+==== nodetool getautorepairconfig
+```
+$> nodetool getautorepairconfig
+repair scheduler configuration:
+	repair_check_interval: 5m
+	repair_max_retries: 3
+	repair_retry_backoff: 30s
+	repair_task_min_duration: 5s
+	history_clear_delete_hosts_buffer_interval: 2h
+configuration for repair_type: full
+	enabled: true
+	min_repair_interval: 24h
+	repair_by_keyspace: false
+	number_of_repair_threads: 1
+	sstable_upper_threshold: 10000
+	table_max_repair_time: 6h
+	ignore_dcs: []
+	repair_primary_token_range_only: true
+	parallel_repair_count: 3
+	parallel_repair_percentage: 3
+	mv_repair_enabled: false
+	initial_scheduler_delay: 5m
+	repair_session_timeout: 3h
+	force_repair_new_node: false
+	token_range_splitter: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
+	token_range_splitter.bytes_per_assignment: 200GiB
+	token_range_splitter.partitions_per_assignment: 1048576
+	token_range_splitter.max_tables_per_assignment: 64
+	token_range_splitter.max_bytes_per_schedule: 100000GiB
+configuration for repair_type: incremental
+	enabled: true
+	min_repair_interval: 24h
+	repair_by_keyspace: false
+	number_of_repair_threads: 1
+	sstable_upper_threshold: 10000
+	table_max_repair_time: 6h
+	ignore_dcs: []
+	repair_primary_token_range_only: true
+	parallel_repair_count: 3
+	parallel_repair_percentage: 3
+	mv_repair_enabled: false
+	initial_scheduler_delay: 5m
+	repair_session_timeout: 3h
+	force_repair_new_node: false
+	token_range_splitter: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
+	token_range_splitter.bytes_per_assignment: 50GiB
+	token_range_splitter.partitions_per_assignment: 1048576
+	token_range_splitter.max_tables_per_assignment: 64
+	token_range_splitter.max_bytes_per_schedule: 100GiB
+configuration for repair_type: preview_repaired
+	enabled: false
+```
+
+==== nodetool autorepairstatus
+```
+$> nodetool autorepairstatus -t incremental
+Active Repairs
+425cea55-09aa-46e0-8911-9f37a4424574
+
+
+$> nodetool autorepairstatus -t full
+Active Repairs
+NONE
+
+```
+
+==== nodetool setautorepairconfig
+```
+$> nodetool setautorepairconfig -t incremental number_of_repair_threads 2
+```
+
+
+
+==== More details
+https://cwiki.apache.org/confluence/display/CASSANDRA/CEP-37+Apache+Cassandra+Automated+Repair+Solution[CEP-37]

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
@@ -415,47 +415,47 @@ public class AutoRepairConfig implements Serializable
 
         // Enable/Disable full auto repair
         public volatile Boolean enabled;
-        //  Repair table by table if this is set to 'false'. If it is 'true', then repair all the tables in a keyspace in one go.
+        // Repair table by table if this is set to 'false'. If it is 'true', then repair all the tables in a keyspace in one go.
         public volatile Boolean repair_by_keyspace;
-        //  Number of repair threads to run for a given invoked Repair Job.
-        //  Once the scheduler schedules one repair session, then howmany threads to use inside that job will be controlled through this parameter.
-        //  This is similar to -j for repair options for the nodetool repair command.
+        // Number of repair threads to run for a given invoked Repair Job.
+        // Once the scheduler schedules one repair session, then howmany threads to use inside that job will be controlled through this parameter.
+        // This is similar to -j for repair options for the nodetool repair command.
         public volatile Integer number_of_repair_threads;
-        //  The number of nodes running repair parallelly. If parallel_repair_percentage is set, it will choose the larger value of the two. The default is 3.
-        //  This configuration controls how many nodes would run repair in parallel.
-        //  The value “3” means, at any given point in time, at most 3 nodes would be running repair in parallel. These selected nodes can be from any datacenters.
-        //  If one or more node(s) finish repair, then the framework automatically picks up the next candidate(s) based on the least repair time.
-        //  It will ensure the maximum number of nodes running repair do not exceed “3”.
+        // The number of nodes running repair parallelly. If parallel_repair_percentage is set, it will choose the larger value of the two.
+        // This configuration controls how many nodes would run repair in parallel.
+        // The value “3” means, at any given point in time, at most 3 nodes would be running repair in parallel. These selected nodes can be from any datacenters.
+        // If one or more node(s) finish repair, then the framework automatically picks up the next candidate(s) based on the least repair time.
+        // It will ensure the maximum number of nodes running repair do not exceed “3”.
         public volatile Integer parallel_repair_count;
-        //  The percentage of nodes in the cluster that run repair parallelly. If parallel_repair_count is set, it will choose the larger value of the two.
-        //  The problem with a fixed number of nodes (parallel_repair_count property) is that in a large-scale environment,
-        //  the nodes keep getting added/removed due to elasticity, so if we have a fixed number, then manual interventions would increase because, on a continuous basis,operators would have to adjust to meet the SLA.
-        //  The default is 3%, which means that 3% of the nodes in the Cassandra cluster would be repaired in parallel.
-        //  So now, if a fleet, an operator won't have to worry about changing the repair frequency, etc., as overall repair time will continue to remain the same even if nodes are added or removed due to elasticity.
-        //  Extremely fewer manual interventions as it will rarely violate the repair SLA for customers
+        // The percentage of nodes in the cluster that run repair parallelly. If parallel_repair_count is set, it will choose the larger value of the two.
+        // The problem with a fixed number of nodes (parallel_repair_count property) is that in a large-scale environment,
+        // the nodes keep getting added/removed due to elasticity, so if we have a fixed number, then manual interventions would increase because, on a continuous basis,operators would have to adjust to meet the SLA.
+        // The default is 3%, which means that 3% of the nodes in the Cassandra cluster would be repaired in parallel.
+        // So now, if a fleet, an operator won't have to worry about changing the repair frequency, etc., as overall repair time will continue to remain the same even if nodes are added or removed due to elasticity.
+        // Extremely fewer manual interventions as it will rarely violate the repair SLA for customers.
         public volatile Integer parallel_repair_percentage;
-        //  Threshold to skip a table if it has too many sstables. The default is 10000. This means, if a table on a node has 10000 or more SSTables, then that table will be skipped.
-        //  This is to avoid penalizing good tables (neighbors) with an outlier.
+        // Threshold to skip a table if it has too many sstables. The default is 10000. This means, if a table on a node has 10000 or more SSTables, then that table will be skipped.
+        // This is to avoid penalizing good tables (neighbors) with an outlier.
         public volatile Integer sstable_upper_threshold;
-        //  Minimum time in hours between repairing the same node again. This is useful for extremely tiny clusters, say 5 nodes, which finishes
-        //  repair quicly. The default is 24 hours. This means that if the scheduler finishes one round on all the nodes in < 24 hours. On a given node it won’t start a new repair round
-        //  until the last repair conducted on a given node is < 24 hours.
+        // Minimum time in hours between repairing the same node again. This is useful for extremely tiny clusters, say 5 nodes, which finishes
+        // repair quicly. The default is 24 hours. This means that if the scheduler finishes one round on all the nodes in < 24 hours. On a given node it won’t start a new repair round
+        // until the last repair conducted on a given node is < 24 hours.
         public volatile DurationSpec.IntSecondsBound min_repair_interval;
-        //  This is useful if you want to completely avoid running repairs in one or more data centers. By default, it is empty, i.e., the framework will repair nodes in all the datacenters.
-        //  If you want to avoid repairing nodes in one or more data centers, then you can specify the data centers in this list.
+        // This is useful if you want to completely avoid running repairs in one or more data centers. By default, it is empty, i.e., the framework will repair nodes in all the datacenters.
+        // If you want to avoid repairing nodes in one or more data centers, then you can specify the data centers in this list.
         public volatile Set<String> ignore_dcs;
-        //  Set this 'true' if AutoRepair should repair only the primary ranges owned by this node; else, 'false'
-        //  It is the same as -pr in nodetool repair options.
+        // Set this 'true' if AutoRepair should repair only the primary ranges owned by this node; else, 'false'.
+        // It is the same as -pr in nodetool repair options.
         public volatile Boolean repair_primary_token_range_only;
-        //  Whether to force immediate repair on new nodes. This is useful if you want to repair newly bootstrapped nodes immediately after they join the ring.
+        // Whether to force immediate repair on new nodes. This is useful if you want to repair newly bootstrapped nodes immediately after they join the ring.
         public volatile Boolean force_repair_new_node;
-        //  Max time for repairing one table on a given node, if exceeded, skip the table. The default is 6 hours.
-        //  Let's say there is a Cassandra cluster in that there are 10 tables belonging to 10 different customers.
-        //  Out of these 10 tables, 1 table is humongous. Repairing this 1 table, say, takes 5 days, in the worst case, but others could finish in just 1 hour.
-        //  Then we would penalize 9 customers just because of one bad actor, and those 9 customers would ping an operator and would require a lot of back-and-forth manual interventions, etc.
-        //  So, the idea here is to penalize the outliers instead of good candidates. This can easily be configured with a higher value if we want to disable the functionality.
+        // Max time for repairing one table on a given node, if exceeded, skip the table.
+        // Let's say there is a Cassandra cluster in that there are 10 tables belonging to 10 different customers.
+        // Out of these 10 tables, 1 table is humongous. Repairing this 1 table, say, takes 5 days, in the worst case, but others could finish in just 1 hour.
+        // Then we would penalize 9 customers just because of one bad actor, and those 9 customers would ping an operator and would require a lot of back-and-forth manual interventions, etc.
+        // So, the idea here is to penalize the outliers instead of good candidates. This can easily be configured with a higher value if we want to disable the functionality.
         public volatile DurationSpec.IntSecondsBound table_max_repair_time;
-        //  If the scheduler should repair MV table or not.
+        // If the scheduler should repair MV table or not.
         public volatile Boolean mv_repair_enabled;
         /**
          * Splitter implementation to use for generating repair assignments.
@@ -464,9 +464,9 @@ public class AutoRepairConfig implements Serializable
          * and have a constructor accepting ({@link RepairType}, {@link java.util.Map})
          */
         public volatile ParameterizedClass token_range_splitter;
-        //  After a node restart, wait for this much delay before scheduler starts running repair; this is to avoid starting repair immediately after a node restart.
+        // After a node restart, wait for this much delay before scheduler starts running repair; this is to avoid starting repair immediately after a node restart.
         public volatile DurationSpec.IntSecondsBound initial_scheduler_delay;
-        //  The major issue with Repair is sometimes repair session hangs; so this timeout is useful to resume such stuck repair sessions.
+        // The major issue with Repair is sometimes repair session hangs; so this timeout is useful to resume such stuck repair sessions.
         public volatile DurationSpec.IntSecondsBound repair_session_timeout;
 
         public String toString()

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
@@ -392,7 +392,9 @@ public class AutoRepairConfig implements Serializable
 
 
             options.get(RepairType.FULL).min_repair_interval = new DurationSpec.IntSecondsBound("24h");
-            // Incremental repairs finish quickly, so they can be run more frequently. Hence, the default is 1 hour.
+            // Incremental repairs operate over unrepaired data and should finish quickly. Running them more frequently keeps
+            // the unrepaired set smaller and thus causes repairs to operate over a smaller set of data, so a more frequent
+            // increase this interval to 24h or longer to reduce the impact of anticompaction caused by incremental repair.
             options.get(RepairType.INCREMENTAL).min_repair_interval = new DurationSpec.IntSecondsBound("1h");
             options.get(RepairType.PREVIEW_REPAIRED).min_repair_interval = new DurationSpec.IntSecondsBound("24h");
 
@@ -475,7 +477,7 @@ public class AutoRepairConfig implements Serializable
         // Maximum time allowed for repairing one table on a given node. If exceeded, the repair proceeds to the
         // next table.
         public volatile DurationSpec.IntSecondsBound table_max_repair_time;
-        // Repairs materialized view if true.
+        // Repairs materialized views if true.
         public volatile Boolean materialized_view_repair_enabled;
         /**
          * Splitter implementation to use for generating repair assignments.

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
@@ -835,7 +835,7 @@ public class AutoRepairUtils
     public static List<String> getAllMVs(RepairType repairType, Keyspace keyspace, TableMetadata tableMetadata)
     {
         List<String> allMvs = new ArrayList<>();
-        if (AutoRepairService.instance.getAutoRepairConfig().getMVRepairEnabled(repairType) && keyspace.getMetadata().views != null)
+        if (AutoRepairService.instance.getAutoRepairConfig().getMaterializedViewRepairEnabled(repairType) && keyspace.getMetadata().views != null)
         {
             Iterator<ViewMetadata> views = keyspace.getMetadata().views.forTable(tableMetadata.id).iterator();
             while (views.hasNext())

--- a/src/java/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitter.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitter.java
@@ -116,10 +116,10 @@ import static org.apache.cassandra.repair.autorepair.AutoRepairUtils.split;
  *         <b>max_tables_per_assignment</b>: The maximum number of tables that can be included in a repair assignment.
  *         This aims to reduce the number of repairs, especially in cases where a large amount of tables exists for
  *         a keyspace.  Note that the splitter will avoid batching tables together if they exceed the other
- *         configuration paramters such as <code>bytes_per_assignment</code> and <code>partitions_per_assignment</code>.
+ *         configuration parameters such as <code>bytes_per_assignment</code> and <code>partitions_per_assignment</code>.
  *     </li>
  *     <li>
- *         <b>max_bytes_per_schedule</b>: The maximum number of bytes to cover an individiual schedule.  This serves
+ *         <b>max_bytes_per_schedule</b>: The maximum number of bytes to cover an individual schedule.  This serves
  *         as a mechanism for throttling the amount of work that can be done on each repair cycle.  One may opt to
  *         reduce this value if the impact of repairs is causing too many load on the cluster, or increase it if
  *         writes outpace the amount of data being repaired.  Alternatively, one may want to choose tuning down or up

--- a/src/java/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitter.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitter.java
@@ -131,6 +131,8 @@ import static org.apache.cassandra.repair.autorepair.AutoRepairUtils.split;
  *     <li>
  *         <b>full</b>:  Configured in a way that attempts to accomplish repairing all data in a schedule, with
  *         individual repairs targeting at most 200GiB of data and 1048576 partitions.
+ *         <b>max_bytes_per_schedule</b> is set to a large value for full repair to attempt to repair all data per
+ *         repair schedule.
  *         <ul>
  *             <li><b>bytes_per_assignment</b>: 200GiB</li>
  *             <li><b>partitions_per_assignment</b>: 2^repair_session_max_tree_depth (2^20 == 1048576 by default)</li>

--- a/src/java/org/apache/cassandra/service/AutoRepairService.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairService.java
@@ -65,10 +65,10 @@ public class AutoRepairService implements AutoRepairServiceMBean
         if (repairType != RepairType.INCREMENTAL)
             return;
 
-        if (DatabaseDescriptor.isMaterializedViewsOnRepairEnabled())
+        if (config.getMaterializedViewRepairEnabled(repairType) && DatabaseDescriptor.isMaterializedViewsOnRepairEnabled())
             throw new ConfigurationException("Cannot run incremental repair while materialized view replay is enabled. Set materialized_views_on_repair_enabled to false.");
 
-        if (DatabaseDescriptor.isCDCOnRepairEnabled())
+        if (DatabaseDescriptor.isCDCEnabled() && DatabaseDescriptor.isCDCOnRepairEnabled())
             throw new ConfigurationException("Cannot run incremental repair while CDC replay is enabled. Set cdc_on_repair_enabled to false.");
     }
 

--- a/src/java/org/apache/cassandra/service/AutoRepairService.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairService.java
@@ -182,7 +182,7 @@ public class AutoRepairService implements AutoRepairServiceMBean
 
     public void setMVRepairEnabled(RepairType repairType, boolean enabled)
     {
-        config.setMVRepairEnabled(repairType, enabled);
+        config.setMaterializedViewRepairEnabled(repairType, enabled);
     }
 
     public void setRepairSessionTimeout(RepairType repairType, String timeout)

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -2515,7 +2515,7 @@ public class NodeProbe implements AutoCloseable
         autoRepairProxy.setPrimaryTokenRangeOnly(repairType, primaryTokenRangeOnly);
     }
 
-    public void setMVRepairEnabled(AutoRepairConfig.RepairType repairType, boolean enabled)
+    public void setMaterializedViewRepairEnabled(AutoRepairConfig.RepairType repairType, boolean enabled)
     {
         autoRepairProxy.setMVRepairEnabled(repairType, enabled);
     }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetAutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetAutoRepairConfig.java
@@ -85,7 +85,7 @@ public class GetAutoRepairConfig extends NodeToolCmd
             appendConfig(sb , "repair_primary_token_range_only", config.getRepairPrimaryTokenRangeOnly(repairType));
             appendConfig(sb , "parallel_repair_count", config.getParallelRepairCount(repairType));
             appendConfig(sb , "parallel_repair_percentage", config.getParallelRepairPercentage(repairType));
-            appendConfig(sb , "mv_repair_enabled", config.getMVRepairEnabled(repairType));
+            appendConfig(sb , "materialized_view_repair_enabled", config.getMaterializedViewRepairEnabled(repairType));
             appendConfig(sb , "initial_scheduler_delay", config.getInitialSchedulerDelay(repairType));
             appendConfig(sb , "repair_session_timeout", config.getRepairSessionTimeout(repairType));
             appendConfig(sb , "force_repair_new_node", config.getForceRepairNewNode(repairType));

--- a/src/java/org/apache/cassandra/tools/nodetool/SetAutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/SetAutoRepairConfig.java
@@ -47,7 +47,7 @@ public class SetAutoRepairConfig extends NodeToolCmd
                   "[start_scheduler|number_of_repair_threads|min_repair_interval|sstable_upper_threshold" +
                   "|enabled|table_max_repair_time|priority_hosts|forcerepair_hosts|ignore_dcs" +
                   "|history_clear_delete_hosts_buffer_interval|repair_primary_token_range_only" +
-                  "|parallel_repair_count|parallel_repair_percentage|mv_repair_enabled|repair_max_retries" +
+                  "|parallel_repair_count|parallel_repair_percentage|materialized_view_repair_enabled|repair_max_retries" +
                   "|repair_retry_backoff|repair_session_timeout|min_repair_task_duration|token_range_splitter.<property>]",
     required = true)
     protected List<String> args = new ArrayList<>();
@@ -160,8 +160,8 @@ public class SetAutoRepairConfig extends NodeToolCmd
             case "parallel_repair_percentage":
                 probe.setParallelRepairPercentage(repairType, Integer.parseInt(paramVal));
                 break;
-            case "mv_repair_enabled":
-                probe.setMVRepairEnabled(repairType, Boolean.parseBoolean(paramVal));
+            case "materialized_view_repair_enabled":
+                probe.setMaterializedViewRepairEnabled(repairType, Boolean.parseBoolean(paramVal));
                 break;
             case "repair_session_timeout":
                 probe.setRepairSessionTimeout(repairType, paramVal);

--- a/test/unit/org/apache/cassandra/config/YamlConfigurationLoaderTest.java
+++ b/test/unit/org/apache/cassandra/config/YamlConfigurationLoaderTest.java
@@ -300,7 +300,7 @@ public class YamlConfigurationLoaderTest
         assertEquals(new DataStorageSpec.IntBytesBound("5B"), config.internode_socket_receive_buffer_size); // Check names backward compatibility (CASSANDRA-17141 and CASSANDRA-15234)
         assertEquals(true, config.auto_repair.enabled);
         assertEquals(new DurationSpec.IntSecondsBound("6h"), config.auto_repair.getAutoRepairTableMaxRepairTime(AutoRepairConfig.RepairType.INCREMENTAL));
-        config.auto_repair.setMVRepairEnabled(AutoRepairConfig.RepairType.INCREMENTAL, false);
+        config.auto_repair.setMaterializedViewRepairEnabled(AutoRepairConfig.RepairType.INCREMENTAL, false);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -676,10 +676,35 @@ public class AutoRepairParameterizedTest extends CQLTester
     }
 
     @Test
+    public void testRepairDoesNotThrowsForIRWithMVReplayButMVRepairDisabled()
+    {
+        AutoRepair.instance.setup();
+        DatabaseDescriptor.setMaterializedViewsOnRepairEnabled(true);
+        AutoRepairService.instance.getAutoRepairConfig().setMaterializedViewRepairEnabled(repairType, false);
+
+        if (repairType == AutoRepairConfig.RepairType.INCREMENTAL)
+        {
+            try
+            {
+                AutoRepair.instance.repair(repairType);
+            }
+            catch (ConfigurationException ignored)
+            {
+                fail("ConfigurationException not expected");
+            }
+        }
+        else
+        {
+            AutoRepair.instance.repair(repairType);
+        }
+    }
+
+    @Test
     public void testRepairThrowsForIRWithMVReplay()
     {
         AutoRepair.instance.setup();
         DatabaseDescriptor.setMaterializedViewsOnRepairEnabled(true);
+        AutoRepairService.instance.getAutoRepairConfig().setMaterializedViewRepairEnabled(repairType, true);
 
         if (repairType == AutoRepairConfig.RepairType.INCREMENTAL)
         {
@@ -703,6 +728,7 @@ public class AutoRepairParameterizedTest extends CQLTester
     public void testRepairThrowsForIRWithCDCReplay()
     {
         AutoRepair.instance.setup();
+        DatabaseDescriptor.setCDCEnabled(true);
         DatabaseDescriptor.setCDCOnRepairEnabled(true);
 
         if (repairType == AutoRepairConfig.RepairType.INCREMENTAL)

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -206,7 +206,7 @@ public class AutoRepairParameterizedTest extends CQLTester
         for (AutoRepairConfig.RepairType repairType : AutoRepairConfig.RepairType.values())
         {
             defaultConfig.setAutoRepairEnabled(repairType, true);
-            defaultConfig.setMVRepairEnabled(repairType, false);
+            defaultConfig.setMaterializedViewRepairEnabled(repairType, false);
         }
 
         // reset the AutoRepairService config to default
@@ -366,15 +366,15 @@ public class AutoRepairParameterizedTest extends CQLTester
     public void testGetAllMVs()
     {
         AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
-        config.setMVRepairEnabled(repairType, false);
-        assertFalse(config.getMVRepairEnabled(repairType));
+        config.setMaterializedViewRepairEnabled(repairType, false);
+        assertFalse(config.getMaterializedViewRepairEnabled(repairType));
         assertEquals(0, AutoRepairUtils.getAllMVs(repairType, keyspace, cfm).size());
 
-        config.setMVRepairEnabled(repairType, true);
+        config.setMaterializedViewRepairEnabled(repairType, true);
 
-        assertTrue(config.getMVRepairEnabled(repairType));
+        assertTrue(config.getMaterializedViewRepairEnabled(repairType));
         assertEquals(Arrays.asList(MV), AutoRepairUtils.getAllMVs(repairType, keyspace, cfm));
-        config.setMVRepairEnabled(repairType, false);
+        config.setMaterializedViewRepairEnabled(repairType, false);
     }
 
 
@@ -382,20 +382,20 @@ public class AutoRepairParameterizedTest extends CQLTester
     public void testMVRepair()
     {
         AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
-        config.setMVRepairEnabled(repairType, true);
+        config.setMaterializedViewRepairEnabled(repairType, true);
         config.setRepairMinInterval(repairType, "0s");
         AutoRepair.instance.repairStates.get(repairType).setLastRepairTime(System.currentTimeMillis());
         AutoRepair.instance.repair(repairType);
         assertEquals(1, AutoRepair.instance.repairStates.get(repairType).getTotalMVTablesConsideredForRepair());
         assertEquals(1, AutoRepairMetricsManager.getMetrics(repairType).totalMVTablesConsideredForRepair.getValue().intValue());
 
-        config.setMVRepairEnabled(repairType, false);
+        config.setMaterializedViewRepairEnabled(repairType, false);
         AutoRepair.instance.repairStates.get(repairType).setLastRepairTime(System.currentTimeMillis());
         AutoRepair.instance.repair(repairType);
         assertEquals(0, AutoRepair.instance.repairStates.get(repairType).getTotalMVTablesConsideredForRepair());
         assertEquals(0, AutoRepairMetricsManager.getMetrics(repairType).totalMVTablesConsideredForRepair.getValue().intValue());
 
-        config.setMVRepairEnabled(repairType, true);
+        config.setMaterializedViewRepairEnabled(repairType, true);
         AutoRepair.instance.repairStates.get(repairType).setLastRepairTime(System.currentTimeMillis());
         AutoRepair.instance.repair(repairType);
         assertEquals(1, AutoRepair.instance.repairStates.get(repairType).getTotalMVTablesConsideredForRepair());
@@ -431,7 +431,7 @@ public class AutoRepairParameterizedTest extends CQLTester
         assert diffMVTable.size() == 10;
 
         int beforeCount = config.getRepairSSTableCountHigherThreshold(repairType);
-        config.setMVRepairEnabled(repairType, true);
+        config.setMaterializedViewRepairEnabled(repairType, true);
         config.setRepairSSTableCountHigherThreshold(repairType, 9);
         assertEquals(0, state.getSkippedTokenRangesCount());
         assertEquals(0, AutoRepairMetricsManager.getMetrics(repairType).skippedTokenRangesCount.getValue().intValue());
@@ -474,7 +474,7 @@ public class AutoRepairParameterizedTest extends CQLTester
     public void testMetrics()
     {
         AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
-        config.setMVRepairEnabled(repairType, true);
+        config.setMaterializedViewRepairEnabled(repairType, true);
         config.setRepairMinInterval(repairType, "0s");
         config.setRepairRetryBackoff("0s");
         config.setAutoRepairTableMaxRepairTime(repairType, "0s");
@@ -512,7 +512,7 @@ public class AutoRepairParameterizedTest extends CQLTester
     public void testRepairWaitsForRepairToFinishBeforeSchedullingNewSession() throws Exception
     {
         AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
-        config.setMVRepairEnabled(repairType, false);
+        config.setMaterializedViewRepairEnabled(repairType, false);
         config.setRepairRetryBackoff("0s");
         when(autoRepairState.getRepairRunnable(any(), any(), any(), anyBoolean()))
         .thenReturn(repairRunnable);
@@ -609,7 +609,7 @@ public class AutoRepairParameterizedTest extends CQLTester
     public void testRepairTakesLastRepairTimeFromDB()
     {
         AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
-        config.setMVRepairEnabled(repairType, true);
+        config.setMaterializedViewRepairEnabled(repairType, true);
         long lastRepairTime = System.currentTimeMillis() - 1000;
         AutoRepairUtils.insertNewRepairHistory(repairType, 0, lastRepairTime);
         AutoRepair.instance.repairStates.get(repairType).setLastRepairTime(0);

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairTest.java
@@ -110,10 +110,22 @@ public class AutoRepairTest extends CQLTester
         instance.setup();
     }
 
+    @Test
+    public void testNoFailureIfMVRepairOnButConfigIsOff()
+    {
+        DatabaseDescriptor.getAutoRepairConfig().setAutoRepairEnabled(RepairType.INCREMENTAL, true);
+        DatabaseDescriptor.getAutoRepairConfig().setMaterializedViewRepairEnabled(RepairType.INCREMENTAL, false);
+        DatabaseDescriptor.setCDCOnRepairEnabled(false);
+        DatabaseDescriptor.setMaterializedViewsOnRepairEnabled(true);
+        AutoRepair instance = new AutoRepair();
+        instance.setup();
+    }
+
     @Test(expected = ConfigurationException.class)
     public void testSetupFailsWhenIREnabledWithMVReplay()
     {
         DatabaseDescriptor.getAutoRepairConfig().setAutoRepairEnabled(RepairType.INCREMENTAL, true);
+        DatabaseDescriptor.getAutoRepairConfig().setMaterializedViewRepairEnabled(RepairType.INCREMENTAL, true);
         DatabaseDescriptor.setCDCOnRepairEnabled(false);
         DatabaseDescriptor.setMaterializedViewsOnRepairEnabled(true);
         AutoRepair instance = new AutoRepair();

--- a/test/unit/org/apache/cassandra/service/AutoRepairServiceBasicTest.java
+++ b/test/unit/org/apache/cassandra/service/AutoRepairServiceBasicTest.java
@@ -87,9 +87,18 @@ public class AutoRepairServiceBasicTest extends CQLTester {
         autoRepairService.setAutoRepairEnabled(AutoRepairConfig.RepairType.INCREMENTAL, true);
     }
 
+    @Test
+    public void testSetAutoRepairEnabledDoesNotThrowForIRWithMVReplayButMVRepairDisabled() {
+        autoRepairService.config = new AutoRepairConfig(true);
+        autoRepairService.config.setMaterializedViewRepairEnabled(AutoRepairConfig.RepairType.INCREMENTAL, false);
+        DatabaseDescriptor.setMaterializedViewsOnRepairEnabled(true);
+        autoRepairService.setAutoRepairEnabled(AutoRepairConfig.RepairType.INCREMENTAL, true);
+    }
+
     @Test(expected = ConfigurationException.class)
     public void testSetAutoRepairEnabledThrowsForIRWithMVReplay() {
         autoRepairService.config = new AutoRepairConfig(true);
+        autoRepairService.config.setMaterializedViewRepairEnabled(AutoRepairConfig.RepairType.INCREMENTAL, true);
         DatabaseDescriptor.setMaterializedViewsOnRepairEnabled(true);
         autoRepairService.setAutoRepairEnabled(AutoRepairConfig.RepairType.INCREMENTAL, true);
     }
@@ -102,10 +111,19 @@ public class AutoRepairServiceBasicTest extends CQLTester {
         autoRepairService.setAutoRepairEnabled(AutoRepairConfig.RepairType.INCREMENTAL, true);
     }
 
+    @Test
+    public void testSetAutoRepairEnabledDoesNotThrowForIRWithCDCReplayButCDCDisabled() {
+        autoRepairService.config = new AutoRepairConfig(true);
+        DatabaseDescriptor.setCDCOnRepairEnabled(true);
+        DatabaseDescriptor.setCDCEnabled(false);
+        autoRepairService.setAutoRepairEnabled(AutoRepairConfig.RepairType.INCREMENTAL, true);
+    }
+
     @Test(expected = ConfigurationException.class)
     public void testSetAutoRepairEnabledThrowsForIRWithCDCReplay() {
         autoRepairService.config = new AutoRepairConfig(true);
         DatabaseDescriptor.setCDCOnRepairEnabled(true);
+        DatabaseDescriptor.setCDCEnabled(true);
         autoRepairService.setAutoRepairEnabled(AutoRepairConfig.RepairType.INCREMENTAL, true);
     }
 

--- a/test/unit/org/apache/cassandra/service/AutoRepairServiceSetterTest.java
+++ b/test/unit/org/apache/cassandra/service/AutoRepairServiceSetterTest.java
@@ -73,7 +73,7 @@ public class AutoRepairServiceSetterTest<T> extends CQLTester {
                 forEachRepairType(true, AutoRepairService.instance::setPrimaryTokenRangeOnly, config::getRepairPrimaryTokenRangeOnly),
                 forEachRepairType(600, AutoRepairService.instance::setParallelRepairPercentage, config::getParallelRepairPercentage),
                 forEachRepairType(700, AutoRepairService.instance::setParallelRepairCount, config::getParallelRepairCount),
-                forEachRepairType(true, AutoRepairService.instance::setMVRepairEnabled, config::getMVRepairEnabled),
+                forEachRepairType(true, AutoRepairService.instance::setMVRepairEnabled, config::getMaterializedViewRepairEnabled),
                 forEachRepairType(ImmutableSet.of(InetAddressAndPort.getLocalHost()), AutoRepairService.instance::setRepairPriorityForHosts, AutoRepairUtils::getPriorityHosts),
                 forEachRepairType(ImmutableSet.of(InetAddressAndPort.getLocalHost()), AutoRepairService.instance::setForceRepairForHosts, AutoRepairServiceSetterTest::isLocalHostForceRepair)
         ).flatMap(Function.identity()).collect(Collectors.toList());

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetAutoRepairConfigTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetAutoRepairConfigTest.java
@@ -284,7 +284,7 @@ public class SetAutoRepairConfigTest
             forEachRepairType("repair_primary_token_range_only", "true", (type) -> verify(probe, times(1)).setPrimaryTokenRangeOnly(type, true)),
             forEachRepairType("parallel_repair_count", "6", (type) -> verify(probe, times(1)).setParallelRepairCount(type, 6)),
             forEachRepairType("parallel_repair_percentage", "7", (type) -> verify(probe, times(1)).setParallelRepairPercentage(type, 7)),
-            forEachRepairType("mv_repair_enabled", "true", (type) -> verify(probe, times(1)).setMVRepairEnabled(type, true)),
+            forEachRepairType("materialized_view_repair_enabled", "true", (type) -> verify(probe, times(1)).setMaterializedViewRepairEnabled(type, true)),
             forEachRepairType("ignore_dcs", "dc1,dc2", (type) -> verify(probe, times(1)).setAutoRepairIgnoreDCs(type, ImmutableSet.of("dc1", "dc2"))),
             forEachRepairType("token_range_splitter.max_bytes_per_schedule", "500GiB", (type) -> verify(probe, times(1)).setAutoRepairTokenRangeSplitterParameter(type, "max_bytes_per_schedule", "500GiB"))
             ).flatMap(Function.identity()).collect(Collectors.toList());


### PR DESCRIPTION
There's quite a bit of really good documentation on configuration sprinkled around code for AutoRepair, but we currently lack documentation in cassandra.yaml, and we should probably move some of this to doc pages.
This ticket covers updating cassandra.yaml for auto_repair and also introducing documentation to docs/ for AutoRepair.
 
The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-20184)


This PR covers the following:

- Cassandra yaml configuration documenatation
- Auto Repair overview doc that describes the feature, configuration, and a link to CEP-37 page 