### PR TITLE
Make AutoRepair's repair_by_keyspace default to true instead of false

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2441,7 +2441,7 @@ storage_compatibility_mode: NONE
 #   global_settings:
 #     # If true, attempts to group tables in the same keyspace into one repair; otherwise, each table is repaired
 #     # individually.
-#     repair_by_keyspace: false
+#     repair_by_keyspace: true
 #     # Number of threads to use for each repair job scheduled by the scheduler. Similar to the -j option in nodetool
 #     # repair.
 #     number_of_repair_threads: 1

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -2315,7 +2315,7 @@ storage_compatibility_mode: NONE
 #   global_settings:
 #     # If true, attempts to group tables in the same keyspace into one repair; otherwise, each table is repaired
 #     # individually.
-#     repair_by_keyspace: false
+#     repair_by_keyspace: true
 #     # Number of threads to use for each repair job scheduled by the scheduler. Similar to the -j option in nodetool
 #     # repair.
 #     number_of_repair_threads: 1

--- a/doc/modules/cassandra/pages/auto-repair/overview.adoc
+++ b/doc/modules/cassandra/pages/auto-repair/overview.adoc
@@ -64,7 +64,7 @@ The following settings can be tailored individually for each repair type.
 |===
 | Name | Default | Description
 | enabled | false | Enable/Disable full/incremental/preview_repaired auto-repair
-| repair_by_keyspace | false | If true, attempts to group tables in the same keyspace into one repair; otherwise,
+| repair_by_keyspace | true | If true, attempts to group tables in the same keyspace into one repair; otherwise,
 each table is repaired individually.
 | number_of_repair_threads | 1 | Number of threads to use for each repair job scheduled by the scheduler. Similar to
 the -j option in nodetool repair.
@@ -146,7 +146,7 @@ repair scheduler configuration:
 configuration for repair_type: full
 	enabled: true
 	min_repair_interval: 24h
-	repair_by_keyspace: false
+	repair_by_keyspace: true
 	number_of_repair_threads: 1
 	sstable_upper_threshold: 10000
 	table_max_repair_time: 6h
@@ -166,7 +166,7 @@ configuration for repair_type: full
 configuration for repair_type: incremental
 	enabled: true
 	min_repair_interval: 1h
-	repair_by_keyspace: false
+	repair_by_keyspace: true
 	number_of_repair_threads: 1
 	sstable_upper_threshold: 10000
 	table_max_repair_time: 6h

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
@@ -426,7 +426,7 @@ public class AutoRepairConfig implements Serializable
             Options opts = new Options();
 
             opts.enabled = false;
-            opts.repair_by_keyspace = false;
+            opts.repair_by_keyspace = true;
             opts.number_of_repair_threads = 1;
             opts.parallel_repair_count = 3;
             opts.parallel_repair_percentage = 3;

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
@@ -130,9 +130,12 @@ public class AutoRepairConfigTest extends CQLTester
     @Test
     public void testSetRepairByKeyspace()
     {
-        config.setRepairByKeyspace(repairType, true);
+        // Should default to true.
+        assertTrue(config.getRepairByKeyspace(repairType));
 
-        assertTrue(config.getOptions(repairType).repair_by_keyspace);
+        config.setRepairByKeyspace(repairType, false);
+
+        assertFalse(config.getOptions(repairType).repair_by_keyspace);
     }
 
     @Test
@@ -418,7 +421,7 @@ public class AutoRepairConfigTest extends CQLTester
         Map<AutoRepairConfig.RepairType, Options> defaultOptions = Options.getDefaultOptionsMap();
         Options options = defaultOptions.get(repairType);
         assertFalse(options.enabled);
-        assertFalse(options.repair_by_keyspace);
+        assertTrue(options.repair_by_keyspace);
         assertEquals(Integer.valueOf(1), options.number_of_repair_threads);
         assertEquals(Integer.valueOf(3), options.parallel_repair_count);
         assertEquals(Integer.valueOf(3), options.parallel_repair_percentage);
@@ -447,7 +450,7 @@ public class AutoRepairConfigTest extends CQLTester
     {
         AutoRepairConfig config = new AutoRepairConfig();
         assertFalse(config.global_settings.enabled);
-        assertFalse(config.global_settings.repair_by_keyspace);
+        assertTrue(config.global_settings.repair_by_keyspace);
         assertEquals(Integer.valueOf(1), config.global_settings.number_of_repair_threads);
         assertEquals(Integer.valueOf(3), config.global_settings.parallel_repair_count);
         assertEquals(Integer.valueOf(3), config.global_settings.parallel_repair_percentage);

--- a/test/unit/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitterTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitterTest.java
@@ -65,7 +65,6 @@ public class RepairTokenRangeSplitterTest extends CQLTester
     {
         CQLTester.setUpClass();
         AutoRepairService.setup();
-        AutoRepairService.instance.getAutoRepairConfig().setRepairByKeyspace(RepairType.FULL, true);
         FULL_RANGE = new Range<>(DatabaseDescriptor.getPartitioner().getMinimumToken(), DatabaseDescriptor.getPartitioner().getMaximumToken());
         DatabaseDescriptor.setSelectedSSTableFormat(DatabaseDescriptor.getSSTableFormats().get(BigFormat.NAME));
     }


### PR DESCRIPTION
Creating repair sessions by table can create an overwhelming amount of repairs, especially with vnodes.

If a repair assignment is too big (> 64 tables by default, or > 200GB for full/50GB for incremental) RepairTokenRangeSplitter will already split into multiple repair assignments.

Adjusts repair_by_keyspace to default to true.

patch by Andy Tolbert; reviewed by Jaydeep Chovatia for CASSANDRA-20232