### PR TITLE
Fix race condition in auto-repair scheduler

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 4.1.6
+ * Fix race condition in auto-repair scheduler (CASSANDRA-20265)
  * Implement minimum repair task duration setting for auto-repair scheduler (CASSANDRA-20160)
  * Implement preview_repaired auto-repair type (CASSANDRA-20046)
  * Refresh stale paxos commit (CASSANDRA-19617)

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -18,6 +18,7 @@
 
 package org.apache.cassandra.repair.autorepair;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.HashSet;
@@ -56,12 +57,17 @@ import org.apache.cassandra.schema.Tables;
 import org.apache.cassandra.service.AutoRepairService;
 import org.apache.cassandra.utils.FBUtilities;
 import org.apache.cassandra.repair.autorepair.AutoRepairUtils.RepairTurn;
+import org.apache.cassandra.utils.concurrent.Condition;
 import org.apache.cassandra.utils.concurrent.Future;
+import org.apache.cassandra.utils.progress.ProgressEvent;
+import org.apache.cassandra.utils.progress.ProgressEventType;
+import org.apache.cassandra.utils.progress.ProgressListener;
 
 import static org.apache.cassandra.concurrent.ExecutorFactory.Global.executorFactory;
 import static org.apache.cassandra.repair.autorepair.AutoRepairUtils.RepairTurn.MY_TURN;
 import static org.apache.cassandra.repair.autorepair.AutoRepairUtils.RepairTurn.MY_TURN_DUE_TO_PRIORITY;
 import static org.apache.cassandra.repair.autorepair.AutoRepairUtils.RepairTurn.MY_TURN_FORCE_REPAIR;
+import static org.apache.cassandra.utils.concurrent.Condition.newOneTimeCondition;
 
 /**
  * AutoRepair scheduler responsible for running different types of repairs.
@@ -69,11 +75,10 @@ import static org.apache.cassandra.repair.autorepair.AutoRepairUtils.RepairTurn.
 public class AutoRepair
 {
     private static final Logger logger = LoggerFactory.getLogger(AutoRepair.class);
+    private static final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
 
     @VisibleForTesting
     protected static Supplier<Long> timeFunc = Clock.Global::currentTimeMillis;
-
-    public static AutoRepair instance = new AutoRepair();
 
     // Sleep for 5 seconds if repair finishes quickly to flush JMX metrics; it happens only for Cassandra nodes with tiny amount of data.
     public static DurationSpec.IntSecondsBound SLEEP_IF_REPAIR_FINISHES_QUICKLY = new DurationSpec.IntSecondsBound("5s");
@@ -95,6 +100,7 @@ public class AutoRepair
     protected static BiConsumer<Long, TimeUnit> sleepFunc = Uninterruptibles::sleepUninterruptibly;
 
     private boolean isSetupDone = false;
+    public static AutoRepair instance = new AutoRepair();
 
     @VisibleForTesting
     protected AutoRepair()
@@ -304,6 +310,7 @@ public class AutoRepair
                 if ((totalProcessedAssignments % config.getRepairThreads(repairType) == 0) ||
                     (totalProcessedAssignments == totalRepairAssignments))
                 {
+                    boolean success = false;
                     int retryCount = 0;
                     Future<?> f = null;
                     while (retryCount <= config.getRepairMaxRetries())
@@ -311,19 +318,21 @@ public class AutoRepair
                         RepairRunnable task = repairState.getRepairRunnable(keyspaceName,
                                                                             Lists.newArrayList(curRepairAssignment.getTableNames()),
                                                                             ranges, primaryRangeOnly);
-                        repairState.resetWaitCondition();
+                        RepairProgressListener listener = new RepairProgressListener(repairType);
+                        task.addProgressListener(listener);
                         f = repairRunnableExecutors.get(repairType).submit(task);
                         try
                         {
                             long jobStartTime = timeFunc.get();
-                            repairState.waitForRepairToComplete(config.getRepairSessionTimeout(repairType));
+                            listener.await();
+                            success = listener.isSuccess();
                             soakAfterRepair(jobStartTime, config.getRepairTaskMinDuration().toMilliseconds());
                         }
                         catch (InterruptedException e)
                         {
                             logger.error("Exception in cond await:", e);
                         }
-                        if (repairState.isSuccess())
+                        if (success)
                         {
                             break;
                         }
@@ -339,7 +348,7 @@ public class AutoRepair
                         retryCount++;
                     }
                     //check repair status
-                    if (repairState.isSuccess())
+                    if (success)
                     {
                         logger.info("Repair completed for range {}-{} for {} tables {}, total assignments: {}," +
                                     "processed assignments: {}", tokenRange.left, tokenRange.right,
@@ -499,5 +508,58 @@ public class AutoRepair
         int succeededTokenRanges = 0;
         int skippedTokenRanges = 0;
         int skippedTables = 0;
+    }
+
+    @VisibleForTesting
+    protected static class RepairProgressListener implements ProgressListener
+    {
+        private final AutoRepairConfig.RepairType repairType;
+        @VisibleForTesting
+        protected boolean success;
+        @VisibleForTesting
+        protected final Condition condition = newOneTimeCondition();
+
+        public RepairProgressListener(AutoRepairConfig.RepairType repairType)
+        {
+            this.repairType = repairType;
+        }
+
+        public void await() throws InterruptedException
+        {
+            //if for some reason we don't hear back on repair progress for sometime
+            if (!condition.await(12, TimeUnit.HOURS))
+            {
+                success = false;
+            }
+        }
+
+        public boolean isSuccess()
+        {
+            return success;
+        }
+
+        @Override
+        public void progress(String tag, ProgressEvent event)
+        {
+            ProgressEventType type = event.getType();
+            String message = String.format("[%s] %s", format.format(System.currentTimeMillis()), event.getMessage());
+            if (type == ProgressEventType.ERROR)
+            {
+                logger.error("Repair failure for repair {}: {}", repairType.toString(), message);
+                success = false;
+                condition.signalAll();
+            }
+            if (type == ProgressEventType.PROGRESS)
+            {
+                message = message + " (progress: " + (int) event.getProgressPercentage() + "%)";
+                logger.debug("Repair progress for repair {}: {}", repairType.toString(), message);
+            }
+            if (type == ProgressEventType.COMPLETE)
+            {
+                logger.debug("Repair completed for repair {}: {}", repairType.toString(), message);
+                success = true;
+                condition.signalAll();
+            }
+        }
     }
 }

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairState.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairState.java
@@ -47,7 +47,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-// AutoRepairState represents the state of automated repair for a given repair type.
+/**
+ * AutoRepairState represents the state of automated repair for a given repair type.
+ */
 public abstract class AutoRepairState
 {
     protected static final Logger logger = LoggerFactory.getLogger(AutoRepairState.class);

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairState.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairState.java
@@ -47,18 +47,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-<<<<<<< HEAD
-import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
-import static org.apache.cassandra.utils.concurrent.Condition.newOneTimeCondition;
-
-/**
- * AutoRepairState represents the state of automated repair for a given repair type.
- */
-public abstract class AutoRepairState implements ProgressListener
-=======
 // AutoRepairState represents the state of automated repair for a given repair type.
 public abstract class AutoRepairState
->>>>>>> 0542e95397 (Fix race condition in auto-repair scheduler)
 {
     protected static final Logger logger = LoggerFactory.getLogger(AutoRepairState.class);
     private final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairState.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairState.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.repair.autorepair;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import org.apache.cassandra.config.DurationSpec;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.view.TableViews;
@@ -37,10 +36,6 @@ import org.apache.cassandra.service.AutoRepairService;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.streaming.PreviewKind;
 import org.apache.cassandra.utils.Clock;
-import org.apache.cassandra.utils.concurrent.Condition;
-import org.apache.cassandra.utils.progress.ProgressEvent;
-import org.apache.cassandra.utils.progress.ProgressEventType;
-import org.apache.cassandra.utils.progress.ProgressListener;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +47,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+<<<<<<< HEAD
 import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
 import static org.apache.cassandra.utils.concurrent.Condition.newOneTimeCondition;
 
@@ -59,6 +55,10 @@ import static org.apache.cassandra.utils.concurrent.Condition.newOneTimeConditio
  * AutoRepairState represents the state of automated repair for a given repair type.
  */
 public abstract class AutoRepairState implements ProgressListener
+=======
+// AutoRepairState represents the state of automated repair for a given repair type.
+public abstract class AutoRepairState
+>>>>>>> 0542e95397 (Fix race condition in auto-repair scheduler)
 {
     protected static final Logger logger = LoggerFactory.getLogger(AutoRepairState.class);
     private final SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss,SSS");
@@ -93,10 +93,6 @@ public abstract class AutoRepairState implements ProgressListener
     protected int skippedTablesCount = 0;
     @VisibleForTesting
     protected AutoRepairHistory longestUnrepairedNode;
-    @VisibleForTesting
-    protected Condition condition = newOneTimeCondition();
-    @VisibleForTesting
-    protected boolean success = true;
     protected final AutoRepairMetrics metrics;
 
     protected AutoRepairState(RepairType repairType)
@@ -109,43 +105,8 @@ public abstract class AutoRepairState implements ProgressListener
 
     protected RepairRunnable getRepairRunnable(String keyspace, RepairOption options)
     {
-        RepairRunnable task = new RepairRunnable(StorageService.instance, StorageService.nextRepairCommand.incrementAndGet(),
+        return new RepairRunnable(StorageService.instance, StorageService.nextRepairCommand.incrementAndGet(),
                                                  options, keyspace);
-        task.addProgressListener(this);
-
-        return task;
-    }
-
-    @Override
-    public void progress(String tag, ProgressEvent event)
-    {
-        ProgressEventType type = event.getType();
-        String message = String.format("[%s] %s", format.format(currentTimeMillis()), event.getMessage());
-        if (type == ProgressEventType.ERROR)
-        {
-            logger.error("Repair failure for {} repair: {}", repairType.toString(), message);
-            success = false;
-            condition.signalAll();
-        }
-        if (type == ProgressEventType.PROGRESS)
-        {
-            message = message + " (progress: " + (int) event.getProgressPercentage() + "%)";
-            logger.debug("Repair progress for {} repair: {}", repairType.toString(), message);
-        }
-        if (type == ProgressEventType.COMPLETE)
-        {
-            success = true;
-            condition.signalAll();
-        }
-    }
-
-    public void waitForRepairToComplete(DurationSpec.IntSecondsBound repairSessionTimeout) throws InterruptedException
-    {
-        //if for some reason we don't hear back on repair progress for sometime
-        if (!condition.await(repairSessionTimeout.toSeconds(), TimeUnit.SECONDS))
-        {
-            success = false;
-        }
     }
 
     public long getLastRepairTime()
@@ -272,11 +233,6 @@ public abstract class AutoRepairState implements ProgressListener
         return skippedTablesCount;
     }
 
-    public boolean isSuccess()
-    {
-        return success;
-    }
-
     public void recordTurn(AutoRepairUtils.RepairTurn turn)
     {
         metrics.recordTurn(turn);
@@ -290,11 +246,6 @@ public abstract class AutoRepairState implements ProgressListener
     public int getTotalDisabledTablesRepairCount()
     {
         return totalDisabledTablesRepairCount;
-    }
-
-    public void resetWaitCondition()
-    {
-        condition = newOneTimeCondition();
     }
 }
 

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -42,6 +42,7 @@ import org.apache.cassandra.repair.messages.RepairOption;
 import org.apache.cassandra.schema.AutoRepairParams;
 import org.apache.cassandra.schema.SystemDistributedKeyspace;
 import org.apache.cassandra.schema.TableParams;
+import org.apache.cassandra.service.StorageService;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -560,7 +561,6 @@ public class AutoRepairParameterizedTest extends CQLTester
     public void testRepairWaitsForRepairToFinishBeforeSchedullingNewSession()
     {
         AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
-        config.setMVRepairEnabled(repairType, false);
         AutoRepair.instance.repairStates.put(repairType, autoRepairState);
         when(autoRepairState.getLastRepairTime()).thenReturn((long) 0);
         AtomicInteger getRepairRunnableCalls = new AtomicInteger();
@@ -693,10 +693,10 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepair.instance.repair(repairType);
 
         // Expect configured retries for each table expected to be repaired
-        assertEquals(config.getRepairMaxRetries()*expectedTablesGoingThroughRepair, sleepCalls.get());
+        assertEquals(config.getRepairMaxRetries()*expectedRepairAssignments, sleepCalls.get());
         verify(autoRepairState, times(1)).setSucceededTokenRangesCount(0);
         verify(autoRepairState, times(1)).setSkippedTokenRangesCount(0);
-        verify(autoRepairState, times(1)).setFailedTokenRangesCount(expectedTablesGoingThroughRepair);
+        verify(autoRepairState, times(1)).setFailedTokenRangesCount(expectedRepairAssignments);
     }
 
     @Test
@@ -729,15 +729,9 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepair.instance.repair(repairType);
 
         assertEquals(1, sleepCalls.get());
-<<<<<<< HEAD
-        verify(autoRepairState, Mockito.times(1)).setSucceededTokenRangesCount(expectedRepairAssignments);
-        verify(autoRepairState, Mockito.times(1)).setSkippedTokenRangesCount(0);
-        verify(autoRepairState, Mockito.times(1)).setFailedTokenRangesCount(0);
-=======
-        verify(autoRepairState, times(1)).setSucceededTokenRangesCount(expectedTablesGoingThroughRepair);
+        verify(autoRepairState, times(1)).setSucceededTokenRangesCount(expectedRepairAssignments);
         verify(autoRepairState, times(1)).setSkippedTokenRangesCount(0);
         verify(autoRepairState, times(1)).setFailedTokenRangesCount(0);
->>>>>>> 0542e95397 (Fix race condition in auto-repair scheduler)
     }
 
     @Test
@@ -835,7 +829,7 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepair.instance.repair(repairType);
 
         assertEquals(1, sleepCalls.get());
-        verify(autoRepairState, times(1)).setSucceededTokenRangesCount(expectedTablesGoingThroughRepair);
+        verify(autoRepairState, times(1)).setSucceededTokenRangesCount(expectedRepairAssignments);
         verify(autoRepairState, times(1)).setSkippedTokenRangesCount(0);
         verify(autoRepairState, times(1)).setFailedTokenRangesCount(0);
     }
@@ -858,7 +852,7 @@ public class AutoRepairParameterizedTest extends CQLTester
 
         AutoRepair.instance.repair(repairType);
 
-        verify(autoRepairState, times(1)).setSucceededTokenRangesCount(expectedTablesGoingThroughRepair);
+        verify(autoRepairState, times(1)).setSucceededTokenRangesCount(expectedRepairAssignments);
         verify(autoRepairState, times(1)).setSkippedTokenRangesCount(0);
         verify(autoRepairState, times(1)).setFailedTokenRangesCount(0);
     }

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -952,6 +952,6 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepair.RepairProgressListener listener = new AutoRepair.RepairProgressListener(repairType);
         listener.progress("test", new ProgressEvent(ProgressEventType.COMPLETE, 0, 0, "test"));
 
-        listener.await();
+        listener.await(new DurationSpec.IntSecondsBound("12h"));
     }
 }

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -24,8 +24,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
@@ -34,7 +36,9 @@ import org.apache.cassandra.config.DurationSpec;
 import org.apache.cassandra.cql3.statements.schema.TableAttributes;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.locator.LocalStrategy;
+import org.apache.cassandra.repair.RepairParallelism;
 import org.apache.cassandra.repair.RepairRunnable;
+import org.apache.cassandra.repair.messages.RepairOption;
 import org.apache.cassandra.schema.AutoRepairParams;
 import org.apache.cassandra.schema.SystemDistributedKeyspace;
 import org.apache.cassandra.schema.TableParams;
@@ -65,10 +69,14 @@ import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.service.AutoRepairService;
+import org.apache.cassandra.streaming.PreviewKind;
 import org.apache.cassandra.utils.FBUtilities;
+import org.apache.cassandra.utils.progress.ProgressEvent;
+import org.apache.cassandra.utils.progress.ProgressEventType;
+import org.apache.cassandra.utils.progress.ProgressListener;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
 
 import static org.apache.cassandra.Util.setAutoRepairEnabled;
 import static org.apache.cassandra.config.CassandraRelevantProperties.SYSTEM_DISTRIBUTED_DEFAULT_RF;
@@ -82,6 +90,8 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -126,7 +136,6 @@ public class AutoRepairParameterizedTest extends CQLTester
         setAutoRepairEnabled(true);
         requireNetwork();
         AutoRepairUtils.setup();
-
 
         cfm = TableMetadata.builder(KEYSPACE, TABLE)
                            .addPartitionKeyColumn("k", UTF8Type.instance)
@@ -276,7 +285,7 @@ public class AutoRepairParameterizedTest extends CQLTester
 
         AutoRepair.instance.repairAsync(repairType);
 
-        verify(mockExecutor, Mockito.times(1)).submit(any(Runnable.class));
+        verify(mockExecutor, times(1)).submit(any(Runnable.class));
     }
 
     @Test
@@ -532,6 +541,10 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepair.instance.repairStates.put(repairType, autoRepairState);
         when(autoRepairState.getRepairRunnable(any(), any(), any(), anyBoolean()))
         .thenReturn(repairRunnable);
+        doAnswer(invocation -> {
+            invocation.getArgument(0, ProgressListener.class).progress("test", new ProgressEvent(ProgressEventType.COMPLETE, 0, 0));
+            return null;
+        }).when(repairRunnable).addProgressListener(any());
         when(autoRepairState.getFailedTokenRangesCount()).thenReturn(10);
         when(autoRepairState.getSucceededTokenRangesCount()).thenReturn(11);
         when(autoRepairState.getLongestUnrepairedSec()).thenReturn(10);
@@ -544,29 +557,30 @@ public class AutoRepairParameterizedTest extends CQLTester
     }
 
     @Test
-    public void testRepairWaitsForRepairToFinishBeforeSchedullingNewSession() throws Exception
+    public void testRepairWaitsForRepairToFinishBeforeSchedullingNewSession()
     {
         AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
-        config.setMaterializedViewRepairEnabled(repairType, false);
-        config.setRepairRetryBackoff("0s");
-        when(autoRepairState.getRepairRunnable(any(), any(), any(), anyBoolean()))
-        .thenReturn(repairRunnable);
+        config.setMVRepairEnabled(repairType, false);
         AutoRepair.instance.repairStates.put(repairType, autoRepairState);
         when(autoRepairState.getLastRepairTime()).thenReturn((long) 0);
-        AtomicInteger resetWaitConditionCalls = new AtomicInteger();
-        AtomicInteger waitForRepairCompletedCalls = new AtomicInteger();
+        AtomicInteger getRepairRunnableCalls = new AtomicInteger();
+        AtomicReference<AutoRepair.RepairProgressListener> prevListener = new AtomicReference<>();
         doAnswer(invocation -> {
-            resetWaitConditionCalls.getAndIncrement();
-            assertEquals("waitForRepairToComplete was called before resetWaitCondition",
-                         resetWaitConditionCalls.get(), waitForRepairCompletedCalls.get() + 1);
-            return null;
-        }).when(autoRepairState).resetWaitCondition();
+            if (getRepairRunnableCalls.getAndIncrement() > 0)
+            {
+                // progress listener from previous repair should be signalled before starting new repair
+                assertTrue(prevListener.get().condition.isSignalled());
+            }
+            getRepairRunnableCalls.incrementAndGet();
+            return repairRunnable;
+        }).when(autoRepairState).getRepairRunnable(any(), any(), any(), anyBoolean());
         doAnswer(invocation -> {
-            waitForRepairCompletedCalls.getAndIncrement();
-            assertEquals("resetWaitCondition was not called before waitForRepairToComplete",
-                         resetWaitConditionCalls.get(), waitForRepairCompletedCalls.get());
+            // sending out a COMPLETE event with a 10ms delay
+            Executors.newScheduledThreadPool(1).schedule(() -> {
+                invocation.getArgument(0, AutoRepair.RepairProgressListener.class).progress("test", new ProgressEvent(ProgressEventType.COMPLETE, 0, 0));
+            }, 10, TimeUnit.MILLISECONDS);
             return null;
-        }).when(autoRepairState).waitForRepairToComplete(config.getRepairSessionTimeout(repairType));
+        }).when(repairRunnable).addProgressListener(any());
 
         AutoRepair.instance.repair(repairType);
         AutoRepair.instance.repair(repairType);
@@ -662,7 +676,10 @@ public class AutoRepairParameterizedTest extends CQLTester
     public void testRepairMaxRetries()
     {
         when(autoRepairState.getRepairRunnable(any(), any(), any(), anyBoolean())).thenReturn(repairRunnable);
-        when(autoRepairState.isSuccess()).thenReturn(false);
+        doAnswer(invocation -> {
+            invocation.getArgument(0, ProgressListener.class).progress("test", new ProgressEvent(ProgressEventType.ERROR, 0, 0));
+            return null;
+        }).when(repairRunnable).addProgressListener(any());
         AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
         AtomicInteger sleepCalls = new AtomicInteger();
         AutoRepair.sleepFunc = (Long duration, TimeUnit unit) -> {
@@ -676,10 +693,10 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepair.instance.repair(repairType);
 
         // Expect configured retries for each table expected to be repaired
-        assertEquals(config.getRepairMaxRetries() * expectedRepairAssignments, sleepCalls.get());
-        verify(autoRepairState, Mockito.times(1)).setSucceededTokenRangesCount(0);
-        verify(autoRepairState, Mockito.times(1)).setSkippedTokenRangesCount(0);
-        verify(autoRepairState, Mockito.times(1)).setFailedTokenRangesCount(expectedRepairAssignments);
+        assertEquals(config.getRepairMaxRetries()*expectedTablesGoingThroughRepair, sleepCalls.get());
+        verify(autoRepairState, times(1)).setSucceededTokenRangesCount(0);
+        verify(autoRepairState, times(1)).setSkippedTokenRangesCount(0);
+        verify(autoRepairState, times(1)).setFailedTokenRangesCount(expectedTablesGoingThroughRepair);
     }
 
     @Test
@@ -694,20 +711,33 @@ public class AutoRepairParameterizedTest extends CQLTester
             assertEquals(TimeUnit.SECONDS, unit);
             assertEquals(config.getRepairRetryBackoff().toSeconds(), (long) duration);
         };
-        when(autoRepairState.isSuccess()).then((invocationOnMock) -> {
-            if (sleepCalls.get() == 0) {
-                return false;
+        doAnswer(invocation -> {
+            if (sleepCalls.get() == 0)
+            {
+                invocation.getArgument(0, ProgressListener.class).progress("test", new ProgressEvent(ProgressEventType.ERROR, 0, 0));
             }
-            return true;
-        });
+            else
+            {
+                invocation.getArgument(0, ProgressListener.class).progress("test", new ProgressEvent(ProgressEventType.COMPLETE, 0, 0));
+            }
+
+            return null;
+        }).when(repairRunnable).addProgressListener(any());
         config.setRepairMinInterval(repairType, "0s");
+        config.setRepairMaxRetries(1);
         AutoRepair.instance.repairStates.put(repairType, autoRepairState);
         AutoRepair.instance.repair(repairType);
 
         assertEquals(1, sleepCalls.get());
+<<<<<<< HEAD
         verify(autoRepairState, Mockito.times(1)).setSucceededTokenRangesCount(expectedRepairAssignments);
         verify(autoRepairState, Mockito.times(1)).setSkippedTokenRangesCount(0);
         verify(autoRepairState, Mockito.times(1)).setFailedTokenRangesCount(0);
+=======
+        verify(autoRepairState, times(1)).setSucceededTokenRangesCount(expectedTablesGoingThroughRepair);
+        verify(autoRepairState, times(1)).setSkippedTokenRangesCount(0);
+        verify(autoRepairState, times(1)).setFailedTokenRangesCount(0);
+>>>>>>> 0542e95397 (Fix race condition in auto-repair scheduler)
     }
 
     @Test
@@ -786,7 +816,10 @@ public class AutoRepairParameterizedTest extends CQLTester
     public void testSoakAfterImmediateRepair()
     {
         when(autoRepairState.getRepairRunnable(any(), any(), any(), anyBoolean())).thenReturn(repairRunnable);
-        when(autoRepairState.isSuccess()).thenReturn(true);
+        doAnswer(invocation -> {
+            invocation.getArgument(0, ProgressListener.class).progress("test", new ProgressEvent(ProgressEventType.COMPLETE, 0, 0));
+            return null;
+        }).when(repairRunnable).addProgressListener(any());
         AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
         config.repair_task_min_duration = new DurationSpec.LongSecondsBound("10s");
         AtomicInteger sleepCalls = new AtomicInteger();
@@ -802,16 +835,19 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepair.instance.repair(repairType);
 
         assertEquals(1, sleepCalls.get());
-        verify(autoRepairState, Mockito.times(1)).setSucceededTokenRangesCount(expectedRepairAssignments);
-        verify(autoRepairState, Mockito.times(1)).setSkippedTokenRangesCount(0);
-        verify(autoRepairState, Mockito.times(1)).setFailedTokenRangesCount(0);
+        verify(autoRepairState, times(1)).setSucceededTokenRangesCount(expectedTablesGoingThroughRepair);
+        verify(autoRepairState, times(1)).setSkippedTokenRangesCount(0);
+        verify(autoRepairState, times(1)).setFailedTokenRangesCount(0);
     }
 
     @Test
     public void testNoSoakAfterRepair()
     {
         when(autoRepairState.getRepairRunnable(any(), any(), any(), anyBoolean())).thenReturn(repairRunnable);
-        when(autoRepairState.isSuccess()).thenReturn(true);
+        doAnswer(invocation -> {
+            invocation.getArgument(0, ProgressListener.class).progress("test", new ProgressEvent(ProgressEventType.COMPLETE, 0, 0));
+            return null;
+        }).when(repairRunnable).addProgressListener(any());
         AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
         config.repair_task_min_duration = new DurationSpec.LongSecondsBound("0s");
         AutoRepair.sleepFunc = (Long duration, TimeUnit unit) -> {
@@ -822,8 +858,105 @@ public class AutoRepairParameterizedTest extends CQLTester
 
         AutoRepair.instance.repair(repairType);
 
-        verify(autoRepairState, Mockito.times(1)).setSucceededTokenRangesCount(expectedRepairAssignments);
-        verify(autoRepairState, Mockito.times(1)).setSkippedTokenRangesCount(0);
-        verify(autoRepairState, Mockito.times(1)).setFailedTokenRangesCount(0);
+        verify(autoRepairState, times(1)).setSucceededTokenRangesCount(expectedTablesGoingThroughRepair);
+        verify(autoRepairState, times(1)).setSkippedTokenRangesCount(0);
+        verify(autoRepairState, times(1)).setFailedTokenRangesCount(0);
+    }
+
+    @Test
+    public void testSchedulerIgnoresErrorsFromUnrelatedRepairRunables()
+    {
+        RepairOption options = new RepairOption(RepairParallelism.PARALLEL, true, repairType == AutoRepairConfig.RepairType.INCREMENTAL, false,
+                                                AutoRepairService.instance.getAutoRepairConfig().getRepairThreads(repairType), Set.of(),
+                                                false, false, false, PreviewKind.NONE, false, true, false, false);
+        AutoRepairState repairState = AutoRepair.instance.repairStates.get(repairType);
+        AutoRepairState spyState = spy(repairState);
+        AtomicReference<RepairRunnable> failingRepair = new AtomicReference<>(new RepairRunnable(StorageService.instance, StorageService.nextRepairCommand.incrementAndGet(), options, keyspace.getName()));
+        AtomicReference<AutoRepair.RepairProgressListener> failingListener = new AtomicReference<>();
+        AtomicReference<RepairRunnable> succeedingRepair = new AtomicReference<>(new RepairRunnable(StorageService.instance, StorageService.nextRepairCommand.incrementAndGet(), options, keyspace.getName()));
+        AtomicInteger repairRunableCalls = new AtomicInteger();
+        doAnswer((InvocationOnMock inv ) -> {
+            RepairRunnable runnable = spy(repairState.getRepairRunnable(inv.getArgument(0), inv.getArgument(1), inv.getArgument(2),
+                                                                        inv.getArgument(3)));
+            if (repairRunableCalls.getAndIncrement() == 0)
+            {
+                // this will be used for first repair job
+                doAnswer(invocation -> {
+                    // repair runnable for the first repair job will immediately fail
+                    failingListener.set(invocation.getArgument(0, AutoRepair.RepairProgressListener.class));
+                    invocation.getArgument(0, ProgressListener.class).progress("test", new ProgressEvent(ProgressEventType.ERROR, 0, 0));
+                    return null;
+                }).when(runnable).addProgressListener(any());
+                failingRepair.set(runnable);
+            }
+            else
+            {
+                // this will be used for subsequent repair jobs
+                doAnswer(invocation -> {
+                    if (repairRunableCalls.get() > 0)
+                    {
+                        // repair runnable for the subsequent repair jobs will immediately complete
+                        invocation.getArgument(0, ProgressListener.class).progress("test", new ProgressEvent(ProgressEventType.COMPLETE, 0, 0));
+
+                    }
+                    // repair runnable for the first repair job will continue firing ERROR events
+                    failingListener.get().progress("test", new ProgressEvent(ProgressEventType.ERROR, 0, 0));
+                    return null;
+                }).when(runnable).addProgressListener(any());
+                succeedingRepair.set(runnable);
+            }
+            return runnable;
+        }).when(spyState).getRepairRunnable(any(), any(), any(), anyBoolean());
+        when(spyState.getLastRepairTime()).thenReturn((long) 0);
+        AutoRepairService.instance.getAutoRepairConfig().setRepairMaxRetries(0);
+        AutoRepair.instance.repairStates.put(repairType, spyState);
+
+        AutoRepair.instance.repair(repairType);
+
+        assertEquals(1, (int) AutoRepairMetricsManager.getMetrics(repairType).failedTokenRangesCount.getValue());
+        // only the first repair job should have failed despite it continuously firing ERROR events
+        verify(spyState, times(1)).setFailedTokenRangesCount(1);
+    }
+
+    @Test
+    public void testProgressError()
+    {
+        AutoRepair.RepairProgressListener listener = new AutoRepair.RepairProgressListener(repairType);
+
+        listener.progress("test", new ProgressEvent(ProgressEventType.ERROR, 0, 0, "test"));
+
+        assertFalse(listener.success);
+        assertTrue(listener.condition.isSignalled());
+    }
+
+    @Test
+    public void testProgressProgress()
+    {
+        AutoRepair.RepairProgressListener listener = new AutoRepair.RepairProgressListener(repairType);
+
+        listener.progress("test", new ProgressEvent(ProgressEventType.PROGRESS, 0, 0, "test"));
+
+        assertFalse(listener.success);
+        assertFalse(listener.condition.isSignalled());
+    }
+
+    @Test
+    public void testProgresComplete()
+    {
+        AutoRepair.RepairProgressListener listener = new AutoRepair.RepairProgressListener(repairType);
+
+        listener.progress("test", new ProgressEvent(ProgressEventType.COMPLETE, 0, 0, "test"));
+
+        assertTrue(listener.success);
+        assertTrue(listener.condition.isSignalled());
+    }
+
+    @Test
+    public void testAwait() throws Exception
+    {
+        AutoRepair.RepairProgressListener listener = new AutoRepair.RepairProgressListener(repairType);
+        listener.progress("test", new ProgressEvent(ProgressEventType.COMPLETE, 0, 0, "test"));
+
+        listener.await();
     }
 }

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.repair.autorepair;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -861,7 +862,7 @@ public class AutoRepairParameterizedTest extends CQLTester
     public void testSchedulerIgnoresErrorsFromUnrelatedRepairRunables()
     {
         RepairOption options = new RepairOption(RepairParallelism.PARALLEL, true, repairType == AutoRepairConfig.RepairType.INCREMENTAL, false,
-                                                AutoRepairService.instance.getAutoRepairConfig().getRepairThreads(repairType), Set.of(),
+                                                AutoRepairService.instance.getAutoRepairConfig().getRepairThreads(repairType), Collections.emptySet(),
                                                 false, false, false, PreviewKind.NONE, false, true, false, false);
         AutoRepairState repairState = AutoRepair.instance.repairStates.get(repairType);
         AutoRepairState spyState = spy(repairState);

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairStateTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairStateTest.java
@@ -83,7 +83,8 @@ public class AutoRepairStateTest extends CQLTester
     }
 
     @Test
-    public void testGetLastRepairTime() {
+    public void testGetLastRepairTime()
+    {
         AutoRepairState state = RepairType.getAutoRepairState(repairType);
         state.lastRepairTimeInMs = 1;
 


### PR DESCRIPTION
Fixes a race condition inside the auto-repair scheduler which can cause a large buildup of active repair jobs.

The conditions for this race condition can be explained by the graph below:
![image](https://github.com/user-attachments/assets/6a84a770-8786-4c3a-b531-9c4ed804e813)

The auto-repair scheduler has a single progress listener object for all repair jobs it schedules. This means that the scheduler cannot differentiate between an event coming from job # 1 and an event coming from job # 2. It simply assumes that the event comes from the last repair job that the scheduler created. Such an assumption leads to a situation where:

1. The scheduler receives a failure from repair job # 1 and schedules repair job # 2 **(1)**

1. The scheduler then receives a 2nd failure from repair job # 1 and assumes that job # 2 failed even though it is still running **(2)**. Repair job # 3 is then scheduled.

1. Both repair job # 2 and repair job # 3 are running at the same time **(3)**