### PR TITLE
Update RepairTokenRangeSplitter to work with BTI-formatted SSTables

### DIFF
--- a/src/java/org/apache/cassandra/io/sstable/format/SSTableScanner.java
+++ b/src/java/org/apache/cassandra/io/sstable/format/SSTableScanner.java
@@ -19,7 +19,6 @@ package org.apache.cassandra.io.sstable.format;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -36,7 +35,6 @@ import org.apache.cassandra.db.rows.UnfilteredRowIterator;
 import org.apache.cassandra.dht.AbstractBounds;
 import org.apache.cassandra.dht.AbstractBounds.Boundary;
 import org.apache.cassandra.dht.Range;
-import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.AbstractRowIndexEntry;
 import org.apache.cassandra.io.sstable.CorruptSSTableException;
 import org.apache.cassandra.io.sstable.ISSTableScanner;
@@ -83,14 +81,6 @@ implements ISSTableScanner
         this.dataRange = dataRange;
         this.rangeIterator = rangeIterator;
         this.listener = listener;
-    }
-
-    public static List<AbstractBounds<PartitionPosition>> makeBounds(SSTableReader sstable, Collection<Range<Token>> tokenRanges)
-    {
-        List<AbstractBounds<PartitionPosition>> boundsList = new ArrayList<>(tokenRanges.size());
-        for (Range<Token> range : Range.normalize(tokenRanges))
-            addRange(sstable, Range.makeRowRange(range), boundsList);
-        return boundsList;
     }
 
     protected static List<AbstractBounds<PartitionPosition>> makeBounds(SSTableReader sstable, DataRange dataRange)

--- a/src/java/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitter.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitter.java
@@ -702,9 +702,14 @@ public class RepairTokenRangeSplitter implements IAutoRepairTokenRangeSplitter
                 logger.error("Error calculating size estimate for {}.{} for range {} on {}", keyspace, table, tokenRange, reader, e);
             }
         }
-        double ratio = approxBytesInRange / (double) totalBytes;
-        // use the ratio from size to estimate the partitions in the range as well
-        long partitions = (long) Math.max(1, Math.ceil(cardinality.cardinality() * ratio));
+
+        long partitions = 0L;
+        if (totalBytes > 0)
+        {
+            // use the ratio from size to estimate the partitions in the range as well
+            double ratio = approxBytesInRange / (double) totalBytes;
+            partitions = (long) Math.max(1, Math.ceil(cardinality.cardinality() * ratio));
+        }
         return new SizeEstimate(repairType, keyspace, table, tokenRange, partitions, approxBytesInRange, totalBytes);
     }
 

--- a/test/unit/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitterTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitterTest.java
@@ -87,6 +87,15 @@ public class RepairTokenRangeSplitterTest extends CQLTester
         DatabaseDescriptor.setSelectedSSTableFormat(DatabaseDescriptor.getSSTableFormats().get(sstableFormat));
         repairRangeSplitter = new RepairTokenRangeSplitter(RepairType.FULL, Collections.emptyMap());
         tableName = createTable("CREATE TABLE %s (k INT PRIMARY KEY, v INT)");
+        // ensure correct format is selected.
+        if (sstableFormat.equalsIgnoreCase(BigFormat.NAME))
+        {
+            assertTrue(BigFormat.isSelected());
+        }
+        else
+        {
+            assertTrue(BtiFormat.isSelected());
+        }
     }
 
     @Test


### PR DESCRIPTION
While doing a review pass on the CEP-37 PR I realized that RepairTokenRangeSplitter could not possibly work with the new BTI sstable format introduced in 5.0 because it explicitly checks for BigTableReader implementations.

In addition, the way it calculates the amount of bytes a range covers in an SSTable is big-format specific.

I noticed that a new utility method
SSTableReader.onDiskSizeForPartitionPositions was added recently in CASSANDRA-20092 that can effectively calculate this for us in an implementation-agnostic way.

This change updates the code to use this method, and also remove any changes we previously made in SSTableScanner and BigTableScanner for this.

Patch by Andy Tolbert; Reviewed by ___ for CASSANDRA-20315