### PR TITLE
Auto repair v2 on 4 1 on 13 feb 2025

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1866,7 +1866,8 @@ drop_compact_storage_enabled: false
 #    excluded_keyspaces: # comma separated list of keyspaces to exclude from the check
 #    excluded_tables: # comma separated list of keyspace.table pairs to exclude from the check
 
-# at least 20% of disk must be unused to run incremental repair
+# At least 20% of disk must be unused to run incremental repair. It is useful to avoid disks filling up during
+# incremental repair as anti-compaction during incremental repair may contribute to additional space temporarily.
 # if you want to disable this feature (the recommendation is not to, but if you want to disable it for whatever reason)
 # then set the ratio to 0.0
 # incremental_repair_disk_headroom_reject_ratio = 0.2;

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1866,6 +1866,11 @@ drop_compact_storage_enabled: false
 #    excluded_keyspaces: # comma separated list of keyspaces to exclude from the check
 #    excluded_tables: # comma separated list of keyspace.table pairs to exclude from the check
 
+# at least 20% of disk must be unused to run incremental repair
+# if you want to disable this feature (the recommendation is not to, but if you want to disable it for whatever reason)
+# then set the ratio to 0.0
+# incremental_repair_disk_headroom_reject_ratio = 0.2;
+
 # Configuration for AutoRepair Scheduler.
 # auto_repair:
 #   # Enable/Disable the auto-repair scheduler.

--- a/src/java/org/apache/cassandra/config/Config.java
+++ b/src/java/org/apache/cassandra/config/Config.java
@@ -34,13 +34,13 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
-import org.apache.cassandra.repair.autorepair.AutoRepairConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.audit.AuditLogOptions;
 import org.apache.cassandra.db.ConsistencyLevel;
 import org.apache.cassandra.fql.FullQueryLoggerOptions;
+import org.apache.cassandra.repair.autorepair.AutoRepairConfig;
 import org.apache.cassandra.service.StartupChecks.StartupCheckType;
 
 /**

--- a/src/java/org/apache/cassandra/config/DurationSpec.java
+++ b/src/java/org/apache/cassandra/config/DurationSpec.java
@@ -17,7 +17,6 @@
  */
 package org.apache.cassandra.config;
 
-import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -40,7 +39,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * users the opportunity to be able to provide config with a unit of their choice in cassandra.yaml as per the available
  * options. (CASSANDRA-15234)
  */
-public abstract class DurationSpec implements Serializable
+public abstract class DurationSpec
 {
     /**
      * The Regexp used to parse the duration provided as String.

--- a/src/java/org/apache/cassandra/config/ParameterizedClass.java
+++ b/src/java/org/apache/cassandra/config/ParameterizedClass.java
@@ -28,7 +28,7 @@ import org.apache.cassandra.utils.Shared;
 import static org.apache.cassandra.utils.Shared.Scope.SIMULATION;
 
 @Shared(scope = SIMULATION)
-public class ParameterizedClass implements Serializable
+public class ParameterizedClass
 {
     public static final String CLASS_NAME = "class_name";
     public static final String PARAMETERS = "parameters";

--- a/src/java/org/apache/cassandra/config/ParameterizedClass.java
+++ b/src/java/org/apache/cassandra/config/ParameterizedClass.java
@@ -17,7 +17,6 @@
  */
 package org.apache.cassandra.config;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 

--- a/src/java/org/apache/cassandra/db/streaming/CassandraStreamReceiver.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraStreamReceiver.java
@@ -23,13 +23,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.github.jbellis.jvector.annotations.VisibleForTesting;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;

--- a/src/java/org/apache/cassandra/db/streaming/CassandraStreamReceiver.java
+++ b/src/java/org/apache/cassandra/db/streaming/CassandraStreamReceiver.java
@@ -26,18 +26,17 @@ import java.util.Set;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
-import org.apache.cassandra.io.sstable.SSTable;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.github.jbellis.jvector.annotations.VisibleForTesting;
+import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.ColumnFamilyStore;
 import org.apache.cassandra.db.Keyspace;
 import org.apache.cassandra.db.Mutation;
 import org.apache.cassandra.db.compaction.OperationType;
 import org.apache.cassandra.db.filter.ColumnFilter;
+import org.apache.cassandra.db.lifecycle.LifecycleNewTracker;
 import org.apache.cassandra.db.lifecycle.LifecycleTransaction;
 import org.apache.cassandra.db.partitions.PartitionUpdate;
 import org.apache.cassandra.db.rows.ThrottledUnfilteredIterator;
@@ -46,6 +45,7 @@ import org.apache.cassandra.db.view.View;
 import org.apache.cassandra.dht.Bounds;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.io.sstable.ISSTableScanner;
+import org.apache.cassandra.io.sstable.SSTable;
 import org.apache.cassandra.io.sstable.SSTableMultiWriter;
 import org.apache.cassandra.io.sstable.format.SSTableReader;
 import org.apache.cassandra.streaming.IncomingStream;
@@ -188,7 +188,8 @@ public class CassandraStreamReceiver implements StreamReceiver
      * For CDC-enabled tables, we want to ensure that the mutations are run through the CommitLog so they
      * can be archived by the CDC process on discard.
      */
-    public boolean requiresWritePath(ColumnFamilyStore cfs)
+    @VisibleForTesting
+    boolean requiresWritePath(ColumnFamilyStore cfs)
     {
         return cdcRequiresWriteCommitLog(cfs)
                || cfs.streamToMemtable()

--- a/src/java/org/apache/cassandra/metrics/AutoRepairMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/AutoRepairMetrics.java
@@ -89,7 +89,6 @@ public class AutoRepairMetrics
             }
         });
 
-
         longestUnrepairedSec = Metrics.register(factory.createMetricName("LongestUnrepairedSec"), new Gauge<Integer>()
         {
             public Integer getValue()

--- a/src/java/org/apache/cassandra/metrics/AutoRepairMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/AutoRepairMetrics.java
@@ -31,20 +31,19 @@ import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
  */
 public class AutoRepairMetrics
 {
-    public Gauge<Integer> repairsInProgress;
-    public Gauge<Integer> nodeRepairTimeInSec;
-    public Gauge<Integer> clusterRepairTimeInSec;
-    public Gauge<Integer> longestUnrepairedSec;
-    public Gauge<Integer> succeededTokenRangesCount;
-    public Gauge<Integer> failedTokenRangesCount;
-    public Gauge<Integer> skippedTokenRangesCount;
-    public Gauge<Integer> skippedTablesCount;
+    public final Gauge<Integer> repairsInProgress;
+    public final Gauge<Integer> nodeRepairTimeInSec;
+    public final Gauge<Integer> clusterRepairTimeInSec;
+    public final Gauge<Integer> longestUnrepairedSec;
+    public final Gauge<Integer> succeededTokenRangesCount;
+    public final Gauge<Integer> failedTokenRangesCount;
+    public final Gauge<Integer> skippedTokenRangesCount;
+    public final Gauge<Integer> skippedTablesCount;
+    public final Gauge<Integer> totalMVTablesConsideredForRepair;
+    public final Gauge<Integer> totalDisabledRepairTables;
     public Counter repairTurnMyTurn;
     public Counter repairTurnMyTurnDueToPriority;
     public Counter repairTurnMyTurnForceRepair;
-    public Gauge<Integer> totalMVTablesConsideredForRepair;
-    public Gauge<Integer> totalDisabledRepairTables;
-
     public AutoRepairMetrics(RepairType repairType)
     {
         AutoRepairMetricsFactory factory = new AutoRepairMetricsFactory(repairType);

--- a/src/java/org/apache/cassandra/metrics/AutoRepairMetricsManager.java
+++ b/src/java/org/apache/cassandra/metrics/AutoRepairMetricsManager.java
@@ -23,6 +23,9 @@ import org.apache.cassandra.repair.autorepair.AutoRepairConfig.RepairType;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * AutoRepair metrics manager holding all the auto-repair related metrics.
+ */
 public class AutoRepairMetricsManager
 {
     private static final Map<RepairType, AutoRepairMetrics> metrics = new ConcurrentHashMap<>();

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -63,6 +63,9 @@ import static org.apache.cassandra.repair.autorepair.AutoRepairUtils.RepairTurn.
 import static org.apache.cassandra.repair.autorepair.AutoRepairUtils.RepairTurn.MY_TURN_DUE_TO_PRIORITY;
 import static org.apache.cassandra.repair.autorepair.AutoRepairUtils.RepairTurn.MY_TURN_FORCE_REPAIR;
 
+/**
+ * AutoRepair scheduler responsible for running different types of repairs.
+ */
 public class AutoRepair
 {
     private static final Logger logger = LoggerFactory.getLogger(AutoRepair.class);

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
@@ -38,6 +38,9 @@ import org.apache.cassandra.config.ParameterizedClass;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.utils.FBUtilities;
 
+/**
+ * Defines configurations for AutoRepair.
+ */
 public class AutoRepairConfig implements Serializable
 {
     // Enable/Disable the auto-repair scheduler.

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
@@ -452,8 +452,8 @@ public class AutoRepairConfig implements Serializable
             opts.table_max_repair_time = new DurationSpec.IntSecondsBound("6h");
             opts.materialized_view_repair_enabled = false;
             opts.token_range_splitter = new ParameterizedClass(DEFAULT_SPLITTER.getName(), Collections.emptyMap());
-            opts.initial_scheduler_delay = new DurationSpec.IntSecondsBound("5m"); // 5 minutes
-            opts.repair_session_timeout = new DurationSpec.IntSecondsBound("3h"); // 3 hours
+            opts.initial_scheduler_delay = new DurationSpec.IntSecondsBound("5m");
+            opts.repair_session_timeout = new DurationSpec.IntSecondsBound("3h");
 
             return opts;
         }

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairState.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairState.java
@@ -55,7 +55,9 @@ import java.util.stream.Collectors;
 import static org.apache.cassandra.utils.Clock.Global.currentTimeMillis;
 import static org.apache.cassandra.utils.concurrent.Condition.newOneTimeCondition;
 
-// AutoRepairState represents the state of automated repair for a given repair type.
+/**
+ * AutoRepairState represents the state of automated repair for a given repair type.
+ */
 public abstract class AutoRepairState implements ProgressListener
 {
     protected static final Logger logger = LoggerFactory.getLogger(AutoRepairState.class);

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairState.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairState.java
@@ -83,17 +83,14 @@ public abstract class AutoRepairState implements ProgressListener
     protected int totalMVTablesConsideredForRepair = 0;
     @VisibleForTesting
     protected int totalDisabledTablesRepairCount = 0;
-
     @VisibleForTesting
     protected int failedTokenRangesCount = 0;
     @VisibleForTesting
     protected int succeededTokenRangesCount = 0;
     @VisibleForTesting
     protected int skippedTokenRangesCount = 0;
-
     @VisibleForTesting
     protected int skippedTablesCount = 0;
-
     @VisibleForTesting
     protected AutoRepairHistory longestUnrepairedNode;
     @VisibleForTesting
@@ -114,7 +111,6 @@ public abstract class AutoRepairState implements ProgressListener
     {
         RepairRunnable task = new RepairRunnable(StorageService.instance, StorageService.nextRepairCommand.incrementAndGet(),
                                                  options, keyspace);
-
         task.addProgressListener(this);
 
         return task;

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
@@ -132,7 +132,6 @@ public class AutoRepairUtils
     COL_REPAIR_TYPE, COL_HOST_ID);
 
     final static String RECORD_FINISH_REPAIR_HISTORY = String.format(
-
     "UPDATE %s.%s SET %s= ?, %s=false WHERE %s = ? AND %s = ?"
     , SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, SystemDistributedKeyspace.AUTO_REPAIR_HISTORY, COL_REPAIR_FINISH_TS,
     COL_FORCE_REPAIR, COL_REPAIR_TYPE, COL_HOST_ID);
@@ -179,10 +178,8 @@ public class AutoRepairUtils
                                                                                                             .forInternalCalls());
         selectStatementRepairPriority = (SelectStatement) QueryProcessor.getStatement(SELECT_REPAIR_PRIORITY, ClientState
                                                                                                               .forInternalCalls());
-
         selectLastRepairTimeForNode = (SelectStatement) QueryProcessor.getStatement(SELECT_LAST_REPAIR_TIME_FOR_NODE, ClientState
                                                                                                                       .forInternalCalls());
-
         delStatementPriorityStatus = (ModificationStatement) QueryProcessor.getStatement(DEL_REPAIR_PRIORITY, ClientState
                                                                                                               .forInternalCalls());
         addPriorityHost = (ModificationStatement) QueryProcessor.getStatement(ADD_PRIORITY_HOST, ClientState
@@ -386,14 +383,11 @@ public class AutoRepairUtils
                                                                                                     ByteBufferUtil.bytes(repairType.toString()),
                                                                                                     ByteBufferUtil.bytes(hostId))),
                                                                       Dispatcher.RequestTime.forImmediateExecution());
-
         UntypedResultSet repairTime = UntypedResultSet.create(rows.result);
-
         if (repairTime.isEmpty())
         {
             return 0;
         }
-
         return repairTime.one().getLong(COL_REPAIR_FINISH_TS);
     }
 
@@ -558,11 +552,9 @@ public class AutoRepairUtils
             int parallelRepairNumber = getMaxNumberOfNodeRunAutoRepair(repairType,
                                                                               autoRepairHistories == null ? 0 : autoRepairHistories.size());
             logger.info("Will run repairs concurrently on {} node(s)", parallelRepairNumber);
-
             if (currentRepairStatus == null || parallelRepairNumber > currentRepairStatus.hostIdsWithOnGoingRepair.size())
             {
                 // more repairs can be run, I might be the new one
-
                 if (autoRepairHistories != null)
                 {
                     logger.info("Auto repair history table has {} records", autoRepairHistories.size());
@@ -604,13 +596,11 @@ public class AutoRepairUtils
                                 "First node in priority list is {}", StorageService.instance.getTokenMetadata().getEndpointForHostId(priorityHostId));
                     return NOT_MY_TURN;
                 }
-
                 if (myId.equals(priorityHostId))
                 {
                     //I have a priority for repair hence its my turn now
                     return MY_TURN_DUE_TO_PRIORITY;
                 }
-
                 // get the longest unrepaired node from the nodes which are not running repair
                 AutoRepairHistory defaultNodeToBeRepaired = getHostWithLongestUnrepairTime(currentRepairStatus.historiesWithoutOnGoingRepair);
                 //check who is next, which is helpful for debugging
@@ -810,7 +800,6 @@ public class AutoRepairUtils
         }
         return repair;
     }
-
 
     public static boolean tableMaxRepairTimeExceeded(RepairType repairType, long startTime)
     {

--- a/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
@@ -75,7 +75,6 @@ public class FixedSplitTokenRangeSplitter implements IAutoRepairTokenRangeSplitt
     {
         return new RepairAssignmentIterator(repairPlans)
         {
-
             @Override
             protected KeyspaceRepairAssignments next(int priority, KeyspaceRepairPlan repairPlan)
             {
@@ -125,7 +124,6 @@ public class FixedSplitTokenRangeSplitter implements IAutoRepairTokenRangeSplitt
                 }
             }
         }
-
         return new KeyspaceRepairAssignments(priority, keyspaceName, repairAssignments);
     }
 
@@ -136,7 +134,6 @@ public class FixedSplitTokenRangeSplitter implements IAutoRepairTokenRangeSplitt
         {
             throw new IllegalArgumentException("Unexpected parameter '" + key + "', must be " + NUMBER_OF_SUBRANGES);
         }
-
         logger.info("Setting {} to {} for repair type {}", key, value, repairType);
         this.numberOfSubranges = Integer.parseInt(value);
     }

--- a/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
@@ -36,6 +36,9 @@ import org.apache.cassandra.service.StorageService;
 
 import static org.apache.cassandra.repair.autorepair.AutoRepairUtils.split;
 
+/**
+ * An implementation that splits token ranges into a fixed number of subranges.
+ */
 public class FixedSplitTokenRangeSplitter implements IAutoRepairTokenRangeSplitter
 {
     private static final Logger logger = LoggerFactory.getLogger(FixedSplitTokenRangeSplitter.class);

--- a/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
@@ -70,7 +70,8 @@ public class FixedSplitTokenRangeSplitter implements IAutoRepairTokenRangeSplitt
     @Override
     public Iterator<KeyspaceRepairAssignments> getRepairAssignments(boolean primaryRangeOnly, List<PrioritizedRepairPlan> repairPlans)
     {
-        return new RepairAssignmentIterator(repairPlans) {
+        return new RepairAssignmentIterator(repairPlans)
+        {
 
             @Override
             protected KeyspaceRepairAssignments next(int priority, KeyspaceRepairPlan repairPlan)

--- a/src/java/org/apache/cassandra/repair/autorepair/RepairAssignmentIterator.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/RepairAssignmentIterator.java
@@ -51,7 +51,6 @@ public abstract class RepairAssignmentIterator implements Iterator<KeyspaceRepai
                 currentIterator = currentPlan.getKeyspaceRepairPlans().iterator();
             }
         }
-
         return currentIterator;
     }
 

--- a/src/java/org/apache/cassandra/schema/AutoRepairParams.java
+++ b/src/java/org/apache/cassandra/schema/AutoRepairParams.java
@@ -31,6 +31,9 @@ import org.apache.cassandra.repair.autorepair.AutoRepairConfig;
 
 import static java.lang.String.format;
 
+/**
+ * AutoRepair table parameters - used to define the auto-repair configuration for a table.
+ */
 public final class AutoRepairParams
 {
     public enum Option

--- a/src/java/org/apache/cassandra/schema/AutoRepairParams.java
+++ b/src/java/org/apache/cassandra/schema/AutoRepairParams.java
@@ -50,7 +50,7 @@ public final class AutoRepairParams
         }
     }
 
-    private ImmutableMap<String, String> options;
+    private final ImmutableMap<String, String> options;
 
     public static final Map<String, String> DEFAULT_OPTIONS = ImmutableMap.of(
     Option.FULL_ENABLED.name().toLowerCase(), Boolean.toString(true),
@@ -149,7 +149,6 @@ public final class AutoRepairParams
     {
         return StringUtils.isNumeric(value);
     }
-
 
     public Map<String, String> options()
     {

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -557,7 +557,6 @@ public final class SchemaKeyspace
                .add("extensions", params.extensions)
                .add("auto_repair", params.autoRepair.asMap());
 
-
         // Only add CDC-enabled flag to schema if it's enabled on the node. This is to work around RTE's post-8099 if a 3.8+
         // node sends table schema to a < 3.8 versioned node with an unknown column.
         if (DatabaseDescriptor.isCDCEnabled())

--- a/src/java/org/apache/cassandra/schema/SystemDistributedKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SystemDistributedKeyspace.java
@@ -185,7 +185,6 @@ public final class SystemDistributedKeyspace
                              + "repair_priority set<uuid>,"
                              + "PRIMARY KEY (repair_type))").build();
 
-
     private static TableMetadata.Builder parse(String table, String description, String cql)
     {
         return CreateTableStatement.parse(format(cql, table), SchemaConstants.DISTRIBUTED_KEYSPACE_NAME)

--- a/src/java/org/apache/cassandra/schema/TableParams.java
+++ b/src/java/org/apache/cassandra/schema/TableParams.java
@@ -135,8 +135,7 @@ public final class TableParams
                             .extensions(params.extensions)
                             .cdc(params.cdc)
                             .readRepair(params.readRepair)
-                            .automatedRepair(params.autoRepair)
-        ;
+                            .automatedRepair(params.autoRepair);
     }
 
     public Builder unbuild()

--- a/src/java/org/apache/cassandra/schema/TableParams.java
+++ b/src/java/org/apache/cassandra/schema/TableParams.java
@@ -58,8 +58,7 @@ public final class TableParams
         CRC_CHECK_CHANCE,
         CDC,
         READ_REPAIR,
-        AUTO_REPAIR,
-        ;
+        AUTO_REPAIR;
 
         @Override
         public String toString()

--- a/src/java/org/apache/cassandra/service/ActiveRepairService.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairService.java
@@ -41,6 +41,9 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.apache.cassandra.concurrent.ExecutorPlus;
 import org.apache.cassandra.config.Config;
 import org.apache.cassandra.config.DurationSpec;
@@ -61,8 +64,6 @@ import org.apache.cassandra.schema.TableMetadata;
 import org.apache.cassandra.streaming.PreviewKind;
 import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.concurrent.CountDownLatch;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import org.apache.cassandra.concurrent.ScheduledExecutors;
 import org.apache.cassandra.config.DatabaseDescriptor;

--- a/src/java/org/apache/cassandra/service/ActiveRepairServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/ActiveRepairServiceMBean.java
@@ -61,4 +61,8 @@ public interface ActiveRepairServiceMBean
     int parentRepairSessionsCount();
     public int getPaxosRepairParallelism();
     public void setPaxosRepairParallelism(int v);
+
+    public double getIncrementalRepairDiskHeadroomRejectRatio();
+
+    public void setIncrementalRepairDiskHeadroomRejectRatio(double value);
 }

--- a/src/java/org/apache/cassandra/service/AutoRepairService.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairService.java
@@ -36,6 +36,9 @@ import java.util.UUID;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 
+/**
+ * Implement all the MBeans for AutoRepair.
+ */
 public class AutoRepairService implements AutoRepairServiceMBean
 {
     public static final String MBEAN_NAME = "org.apache.cassandra.db:type=AutoRepairService";

--- a/src/java/org/apache/cassandra/service/AutoRepairServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairServiceMBean.java
@@ -20,6 +20,9 @@ package org.apache.cassandra.service;
 
 import java.util.Set;
 
+/**
+ * Defines all the MBeans exposed for AutoRepair.
+ */
 public interface AutoRepairServiceMBean
 {
     /**

--- a/src/java/org/apache/cassandra/service/AutoRepairServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairServiceMBean.java
@@ -25,9 +25,6 @@ import java.util.Set;
  */
 public interface AutoRepairServiceMBean
 {
-    /**
-     * Enable or disable auto-repair for a given repair type
-     */
     public void setAutoRepairEnabled(String repairType, boolean enabled);
 
     public void setRepairThreads(String repairType, int repairThreads);

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1352,7 +1352,7 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         AutoRepairService.setup();
         if (DatabaseDescriptor.getAutoRepairConfig().isAutoRepairSchedulingEnabled())
         {
-            logger.info("Enable auto-repair scheduling");
+            logger.info("Enabling auto-repair scheduling");
             AutoRepair.instance.setup();
         }
         logger.info("AutoRepair setup complete!");

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -2164,22 +2164,22 @@ public class NodeProbe implements AutoCloseable
         autoRepairProxy.setAutoRepairEnabled(repairType, enabled);
     }
 
-    public void setRepairThreads(String repairType, int repairThreads)
+    public void setAutoRepairThreads(String repairType, int repairThreads)
     {
         autoRepairProxy.setRepairThreads(repairType, repairThreads);
     }
 
-    public void setRepairPriorityForHosts(String repairType, String commaSeparatedHostSet)
+    public void setAutoRepairPriorityForHosts(String repairType, String commaSeparatedHostSet)
     {
         autoRepairProxy.setRepairPriorityForHosts(repairType, commaSeparatedHostSet);
     }
 
-    public void setForceRepairForHosts(String repairType, String commaSeparatedHostSet)
+    public void setAutoRepairForceRepairForHosts(String repairType, String commaSeparatedHostSet)
     {
         autoRepairProxy.setForceRepairForHosts(repairType, commaSeparatedHostSet);
     }
 
-    public void setRepairMinInterval(String repairType, String minRepairInterval)
+    public void setAutoRepairMinInterval(String repairType, String minRepairInterval)
     {
         autoRepairProxy.setRepairMinInterval(repairType, minRepairInterval);
     }
@@ -2189,7 +2189,7 @@ public class NodeProbe implements AutoCloseable
         autoRepairProxy.setAutoRepairHistoryClearDeleteHostsBufferDuration(duration);
     }
 
-    public void startScheduler()
+    public void startAutoRepairScheduler()
     {
         autoRepairProxy.startScheduler();
     }
@@ -2209,7 +2209,7 @@ public class NodeProbe implements AutoCloseable
         autoRepairProxy.setAutoRepairMinRepairTaskDuration(duration);
     }
 
-    public void setRepairSSTableCountHigherThreshold(String repairType, int ssTableHigherThreshold)
+    public void setAutoRepairSSTableCountHigherThreshold(String repairType, int ssTableHigherThreshold)
     {
         autoRepairProxy.setRepairSSTableCountHigherThreshold(repairType, ssTableHigherThreshold);
     }
@@ -2224,22 +2224,22 @@ public class NodeProbe implements AutoCloseable
         autoRepairProxy.setIgnoreDCs(repairType, ignoreDCs);
     }
 
-    public void setParallelRepairPercentage(String repairType, int percentage)
+    public void setAutoRepairParallelRepairPercentage(String repairType, int percentage)
     {
         autoRepairProxy.setParallelRepairPercentage(repairType, percentage);
     }
 
-    public void setParallelRepairCount(String repairType, int count)
+    public void setAutoRepairParallelRepairCount(String repairType, int count)
     {
         autoRepairProxy.setParallelRepairCount(repairType, count);
     }
 
-    public void setPrimaryTokenRangeOnly(String repairType, boolean primaryTokenRangeOnly)
+    public void setAutoRepairPrimaryTokenRangeOnly(String repairType, boolean primaryTokenRangeOnly)
     {
         autoRepairProxy.setPrimaryTokenRangeOnly(repairType, primaryTokenRangeOnly);
     }
 
-    public void setMaterializedViewRepairEnabled(String repairType, boolean enabled)
+    public void setAutoRepairMaterializedViewRepairEnabled(String repairType, boolean enabled)
     {
         autoRepairProxy.setMVRepairEnabled(repairType, enabled);
     }
@@ -2249,17 +2249,17 @@ public class NodeProbe implements AutoCloseable
         return ssProxy.mutateSSTableRepairedState(repair, preview, keyspace, tables);
     }
 
-    public List<String> getTablesForKeyspace(String keyspace)
+    public List<String> getAutoRepairTablesForKeyspace(String keyspace)
     {
         return ssProxy.getTablesForKeyspace(keyspace);
     }
 
-    public void setRepairSessionTimeout(String repairType, String timeout)
+    public void setAutoRepairSessionTimeout(String repairType, String timeout)
     {
         autoRepairProxy.setRepairSessionTimeout(repairType, timeout);
     }
 
-    public Set<String> getOnGoingRepairHostIds(String repairType)
+    public Set<String> getAutoRepairOnGoingRepairHostIds(String repairType)
     {
         return autoRepairProxy.getOnGoingRepairHostIds(repairType);
     }

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -157,7 +157,6 @@ public class NodeProbe implements AutoCloseable
     protected PermissionsCacheMBean pcProxy;
     protected RolesCacheMBean rcProxy;
     protected AutoRepairServiceMBean autoRepairProxy;
-
     protected Output output;
     private boolean failed;
 

--- a/src/java/org/apache/cassandra/tools/nodetool/AutoRepairStatus.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/AutoRepairStatus.java
@@ -31,6 +31,9 @@ import org.apache.cassandra.tools.nodetool.formatter.TableBuilder;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+/**
+ * Provides currently running auto-repair tasks.
+ */
 @Command(name = "autorepairstatus", description = "Print autorepair status")
 public class AutoRepairStatus extends NodeTool.NodeToolCmd
 {
@@ -52,7 +55,7 @@ public class AutoRepairStatus extends NodeTool.NodeToolCmd
 
         TableBuilder table = new TableBuilder();
         table.add("Active Repairs");
-        Set<String> ongoingRepairHostIds = probe.getOnGoingRepairHostIds(repairType);
+        Set<String> ongoingRepairHostIds = probe.getAutoRepairOnGoingRepairHostIds(repairType);
         table.add(getSetString(ongoingRepairHostIds));
         table.printTo(out);
     }

--- a/src/java/org/apache/cassandra/tools/nodetool/GetAutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/GetAutoRepairConfig.java
@@ -25,6 +25,9 @@ import io.airlift.airline.Command;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool.NodeToolCmd;
 
+/**
+ * Prints all the configurations for AutoRepair through nodetool.
+ */
 @Command(name = "getautorepairconfig", description = "Print autorepair configurations")
 public class GetAutoRepairConfig extends NodeToolCmd
 {

--- a/src/java/org/apache/cassandra/tools/nodetool/SSTableRepairedSet.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/SSTableRepairedSet.java
@@ -31,6 +31,9 @@ import org.apache.cassandra.exceptions.InvalidRequestException;
 import org.apache.cassandra.tools.NodeProbe;
 import org.apache.cassandra.tools.NodeTool;
 
+/**
+ * Provides a way to set the repaired state of SSTables without any downtime through nodetool.
+ */
 @Command(name = "sstablerepairedset", description = "Set the repaired state of SSTables for given keyspace/tables")
 public class SSTableRepairedSet extends NodeTool.NodeToolCmd
 {
@@ -87,7 +90,7 @@ public class SSTableRepairedSet extends NodeTool.NodeToolCmd
             {
                 sstableList.addAll(probe.mutateSSTableRepairedState(isRepaired, !reallySet, keyspace,
                                                                     tables.isEmpty()
-                                                                    ? probe.getTablesForKeyspace(keyspace) // mutate all tables
+                                                                    ? probe.getAutoRepairTablesForKeyspace(keyspace) // mutate all tables
                                                                     : tables)); // mutate specific tables
             }
             catch (InvalidRequestException e)

--- a/src/java/org/apache/cassandra/tools/nodetool/SetAutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/SetAutoRepairConfig.java
@@ -35,6 +35,9 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+/**
+ * Allows to set AutoRepair configuration through nodetool.
+ */
 @Command(name = "setautorepairconfig", description = "sets the autorepair configuration")
 public class SetAutoRepairConfig extends NodeToolCmd
 {
@@ -77,7 +80,7 @@ public class SetAutoRepairConfig extends NodeToolCmd
             case "start_scheduler":
                 if (Boolean.parseBoolean(paramVal))
                 {
-                    probe.startScheduler();
+                    probe.startAutoRepairScheduler();
                 }
                 return;
             case "history_clear_delete_hosts_buffer_interval":
@@ -113,13 +116,13 @@ public class SetAutoRepairConfig extends NodeToolCmd
                 probe.setAutoRepairEnabled(repairTypeStr, Boolean.parseBoolean(paramVal));
                 break;
             case "number_of_repair_threads":
-                probe.setRepairThreads(repairTypeStr, Integer.parseInt(paramVal));
+                probe.setAutoRepairThreads(repairTypeStr, Integer.parseInt(paramVal));
                 break;
             case "min_repair_interval":
-                probe.setRepairMinInterval(repairTypeStr, paramVal);
+                probe.setAutoRepairMinInterval(repairTypeStr, paramVal);
                 break;
             case "sstable_upper_threshold":
-                probe.setRepairSSTableCountHigherThreshold(repairTypeStr, Integer.parseInt(paramVal));
+                probe.setAutoRepairSSTableCountHigherThreshold(repairTypeStr, Integer.parseInt(paramVal));
                 break;
             case "table_max_repair_time":
                 probe.setAutoRepairTableMaxRepairTime(repairTypeStr, paramVal);
@@ -127,11 +130,11 @@ public class SetAutoRepairConfig extends NodeToolCmd
             case "priority_hosts":
                 if (paramVal!= null && !paramVal.isEmpty())
                 {
-                    probe.setRepairPriorityForHosts(repairTypeStr, paramVal);
+                    probe.setAutoRepairPriorityForHosts(repairTypeStr, paramVal);
                 }
                 break;
             case "forcerepair_hosts":
-                probe.setForceRepairForHosts(repairTypeStr, paramVal);
+                probe.setAutoRepairForceRepairForHosts(repairTypeStr, paramVal);
                 break;
             case "ignore_dcs":
                 Set<String> ignoreDCs = new HashSet<>();
@@ -142,19 +145,19 @@ public class SetAutoRepairConfig extends NodeToolCmd
                 probe.setAutoRepairIgnoreDCs(repairTypeStr, ignoreDCs);
                 break;
             case "repair_primary_token_range_only":
-                probe.setPrimaryTokenRangeOnly(repairTypeStr, Boolean.parseBoolean(paramVal));
+                probe.setAutoRepairPrimaryTokenRangeOnly(repairTypeStr, Boolean.parseBoolean(paramVal));
                 break;
             case "parallel_repair_count":
-                probe.setParallelRepairCount(repairTypeStr, Integer.parseInt(paramVal));
+                probe.setAutoRepairParallelRepairCount(repairTypeStr, Integer.parseInt(paramVal));
                 break;
             case "parallel_repair_percentage":
-                probe.setParallelRepairPercentage(repairTypeStr, Integer.parseInt(paramVal));
+                probe.setAutoRepairParallelRepairPercentage(repairTypeStr, Integer.parseInt(paramVal));
                 break;
             case "materialized_view_repair_enabled":
-                probe.setMaterializedViewRepairEnabled(repairTypeStr, Boolean.parseBoolean(paramVal));
+                probe.setAutoRepairMaterializedViewRepairEnabled(repairTypeStr, Boolean.parseBoolean(paramVal));
                 break;
             case "repair_session_timeout":
-                probe.setRepairSessionTimeout(repairTypeStr, paramVal);
+                probe.setAutoRepairSessionTimeout(repairTypeStr, paramVal);
                 break;
             default:
                 throw new IllegalArgumentException("Unknown parameter: " + paramType);

--- a/src/java/org/apache/cassandra/utils/FBUtilities.java
+++ b/src/java/org/apache/cassandra/utils/FBUtilities.java
@@ -50,10 +50,6 @@ import com.google.common.base.Suppliers;
 
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.apache.cassandra.io.util.File;
-import org.apache.cassandra.io.util.FileInputStreamPlus;
-import org.apache.cassandra.io.util.FileOutputStreamPlus;
-import org.apache.cassandra.utils.concurrent.*;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,9 +78,13 @@ import org.apache.cassandra.io.sstable.metadata.MetadataType;
 import org.apache.cassandra.io.sstable.metadata.ValidationMetadata;
 import org.apache.cassandra.io.util.DataOutputBuffer;
 import org.apache.cassandra.io.util.DataOutputBufferFixed;
+import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.io.util.FileInputStreamPlus;
+import org.apache.cassandra.io.util.FileOutputStreamPlus;
 import org.apache.cassandra.io.util.FileUtils;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.security.ISslContextFactory;
+import org.apache.cassandra.utils.concurrent.FutureCombiner;
 import org.apache.cassandra.utils.concurrent.UncheckedInterruptedException;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.LINE_SEPARATOR;

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
@@ -42,6 +42,9 @@ import org.apache.cassandra.service.AutoRepairService;
 import static org.apache.cassandra.schema.SchemaConstants.DISTRIBUTED_KEYSPACE_NAME;
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.repair.autorepair.AutoRepair}
+ */
 public class AutoRepairSchedulerTest extends TestBaseImpl
 {
 

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
@@ -47,7 +47,6 @@ import static org.junit.Assert.assertEquals;
  */
 public class AutoRepairSchedulerTest extends TestBaseImpl
 {
-
     private static Cluster cluster;
     static SimpleDateFormat sdf;
 

--- a/test/unit/org/apache/cassandra/config/YamlConfigurationLoaderTest.java
+++ b/test/unit/org/apache/cassandra/config/YamlConfigurationLoaderTest.java
@@ -228,11 +228,11 @@ public class YamlConfigurationLoaderTest
                                                                "optional", false,
                                                                "enabled", true);
         Map<String, Object> autoRepairConfig = ImmutableMap.of("enabled", true,
-                                                               "global_settings", ImmutableMap.of("number_of_repair_threads",
-                                                                                                  1),
-                                                               "repair_type_overrides", ImmutableMap.of(
-        "full", ImmutableMap.of("number_of_repair_threads",
-                                2)));
+                                                               "global_settings",
+                                                                        ImmutableMap.of("number_of_repair_threads", 1),
+                                                               "repair_type_overrides",
+                                                                        ImmutableMap.of("full",
+                                                                                    ImmutableMap.of("number_of_repair_threads", 2)));
         Map<String,Object> map = new ImmutableMap.Builder<String, Object>()
                                  .put("storage_port", storagePort)
                                  .put("commitlog_sync", commitLogSync)

--- a/test/unit/org/apache/cassandra/config/YamlConfigurationLoaderTest.java
+++ b/test/unit/org/apache/cassandra/config/YamlConfigurationLoaderTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import org.apache.cassandra.distributed.shared.WithProperties;
 import org.apache.cassandra.io.util.File;
+import org.apache.cassandra.repair.autorepair.AutoRepairConfig;
 import org.yaml.snakeyaml.error.YAMLException;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.CONFIG_ALLOW_SYSTEM_PROPERTIES;
@@ -40,7 +41,6 @@ import static org.apache.cassandra.config.DataStorageSpec.DataStorageUnit.KIBIBY
 import static org.apache.cassandra.config.YamlConfigurationLoader.SYSTEM_PROPERTY_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import org.apache.cassandra.repair.autorepair.AutoRepairConfig;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/test/unit/org/apache/cassandra/db/streaming/CassandraStreamReceiverTest.java
+++ b/test/unit/org/apache/cassandra/db/streaming/CassandraStreamReceiverTest.java
@@ -35,6 +35,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.db.streaming.CassandraStreamReceiver}
+ */
 public class CassandraStreamReceiverTest extends CQLTester
 {
     @Mock

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigRepairTypeTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigRepairTypeTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.cassandra.repair.autorepair;
 
-
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
@@ -44,6 +44,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.repair.autorepair.AutoRepairConfig}
+ */
 @RunWith(Parameterized.class)
 public class AutoRepairConfigTest extends CQLTester
 {

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
@@ -52,7 +52,7 @@ public class AutoRepairConfigTest extends CQLTester
 {
     private AutoRepairConfig config;
 
-    private Set<String> testSet = ImmutableSet.of("dc1");
+    private final Set<String> testSet = ImmutableSet.of("dc1");
 
     @Parameterized.Parameter
     public AutoRepairConfig.RepairType repairType;

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairKeyspaceTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairKeyspaceTest.java
@@ -34,6 +34,9 @@ import org.apache.cassandra.schema.KeyspaceMetadata;
 import org.apache.cassandra.schema.SystemDistributedKeyspace;
 import org.apache.cassandra.schema.TableMetadata;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.schema.SystemDistributedKeyspace}
+ */
 public class AutoRepairKeyspaceTest
 {
     private static final Set<String> tables = ImmutableSet.of(

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairKeyspaceTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairKeyspaceTest.java
@@ -51,7 +51,6 @@ public class AutoRepairKeyspaceTest
         AutoRepair.SLEEP_IF_REPAIR_FINISHES_QUICKLY = new DurationSpec.IntSecondsBound("0s");
     }
 
-
     @Test
     public void testEnsureAutoRepairTablesArePresent()
     {

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -85,6 +85,9 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.repair.autorepair.AutoRepair}
+ */
 @RunWith(Parameterized.class)
 public class AutoRepairParameterizedTest extends CQLTester
 {

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -758,7 +758,6 @@ public class AutoRepairParameterizedTest extends CQLTester
         }
     }
 
-
     @Test
     public void testRepairThrowsForIRWithCDCReplay()
     {

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairStateFactoryTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairStateFactoryTest.java
@@ -26,6 +26,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.repair.autorepair.AutoRepairConfig.RepairType}
+ */
 public class AutoRepairStateFactoryTest
 {
     @Test

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairStateTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairStateTest.java
@@ -49,6 +49,9 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.repair.autorepair.AutoRepairState}
+ */
 @RunWith(Parameterized.class)
 public class AutoRepairStateTest extends CQLTester
 {

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairTest.java
@@ -41,6 +41,9 @@ import static org.apache.cassandra.Util.setAutoRepairEnabled;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.repair.autorepair.AutoRepair}
+ */
 public class AutoRepairTest extends CQLTester
 {
     @BeforeClass

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairUtilsTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairUtilsTest.java
@@ -68,6 +68,9 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.repair.autorepair.AutoRepairUtils}
+ */
 public class AutoRepairUtilsTest extends CQLTester
 {
     static RepairType repairType = RepairType.INCREMENTAL;

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairUtilsTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairUtilsTest.java
@@ -73,7 +73,7 @@ import static org.mockito.Mockito.when;
  */
 public class AutoRepairUtilsTest extends CQLTester
 {
-    static RepairType repairType = RepairType.INCREMENTAL;
+    static final RepairType repairType = RepairType.INCREMENTAL;
     static UUID hostId;
 
     static InetAddressAndPort localEndpoint;
@@ -147,7 +147,6 @@ public class AutoRepairUtilsTest extends CQLTester
         assertEquals(1, result.size());
         assertTrue(result.one().getBoolean(COL_FORCE_REPAIR));
     }
-
 
     @Test
     public void testClearDeleteHosts()
@@ -281,7 +280,6 @@ public class AutoRepairUtilsTest extends CQLTester
 
         assertEquals(2, count);
     }
-
 
     @Test
     public void testGetMaxNumberOfNodeRunAutoRepairInGroup_percentage()

--- a/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterTest.java
@@ -48,6 +48,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.repair.autorepair.FixedSplitTokenRangeSplitter}
+ */
 @RunWith(Parameterized.class)
 public class FixedSplitTokenRangeSplitterTest extends CQLTester
 {

--- a/test/unit/org/apache/cassandra/repair/autorepair/PrioritizedRepairPlanTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/PrioritizedRepairPlanTest.java
@@ -30,6 +30,9 @@ import org.apache.cassandra.cql3.CQLTester;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.repair.autorepair.PrioritizedRepairPlan}
+ */
 public class PrioritizedRepairPlanTest extends CQLTester
 {
 

--- a/test/unit/org/apache/cassandra/repair/autorepair/PrioritizedRepairPlanTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/PrioritizedRepairPlanTest.java
@@ -35,7 +35,6 @@ import static org.junit.Assert.assertTrue;
  */
 public class PrioritizedRepairPlanTest extends CQLTester
 {
-
     @Test
     public void testBuildWithDifferentPriorities()
     {
@@ -162,5 +161,4 @@ public class PrioritizedRepairPlanTest extends CQLTester
         assertEquals(5, prioritizedRepairPlans.get(0).getPriority());
         assertEquals(table1, prioritizedRepairPlans.get(0).getKeyspaceRepairPlans().get(0).getTableNames().get(0));
     }
-
 }

--- a/test/unit/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitterTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitterTest.java
@@ -356,7 +356,6 @@ public class RepairTokenRangeSplitterTest extends CQLTester
         return new SizeEstimate(RepairType.INCREMENTAL, KEYSPACE, "table1", FULL_RANGE, 1, sizeInRange.toBytes(), totalSize.toBytes());
     }
 
-
     private void insertAndFlushSingleTable() throws Throwable
     {
         execute("INSERT INTO %s (k, v) values (?, ?)", 1, 1);

--- a/test/unit/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitterTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitterTest.java
@@ -31,6 +31,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.config.DataStorageSpec.LongMebibytesBound;
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -53,6 +55,10 @@ import static org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter.MA
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter}
+ */
+@RunWith(Parameterized.class)
 public class RepairTokenRangeSplitterTest extends CQLTester
 {
     private RepairTokenRangeSplitter repairRangeSplitter;

--- a/test/unit/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitterTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitterTest.java
@@ -78,16 +78,19 @@ public class RepairTokenRangeSplitterTest extends CQLTester
     public void testSizePartitionCount() throws Throwable
     {
         insertAndFlushTable(tableName, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        Refs<SSTableReader> sstables = RepairTokenRangeSplitter.getSSTableReaderRefs(RepairType.FULL, KEYSPACE, tableName, FULL_RANGE);
-        assertEquals(10, sstables.iterator().next().getEstimatedPartitionSize().count());
-        SizeEstimate sizes = RepairTokenRangeSplitter.getSizesForRangeOfSSTables(RepairType.FULL, KEYSPACE, tableName, FULL_RANGE, sstables);
-        assertEquals(10, sizes.partitions);
+        try (Refs<SSTableReader> sstables = RepairTokenRangeSplitter.getSSTableReaderRefs(RepairType.FULL, KEYSPACE, tableName, FULL_RANGE))
+        {
+            assertEquals(10, sstables.iterator().next().getEstimatedPartitionSize().count());
+            SizeEstimate sizes = RepairTokenRangeSplitter.getSizesForRangeOfSSTables(RepairType.FULL, KEYSPACE, tableName, FULL_RANGE, sstables);
+            assertEquals(10, sizes.partitions);
+        }
     }
 
     @Test
     public void testSizePartitionCountSplit() throws Throwable
     {
-        int[] values = new int[10000];
+        int partitionCount = 100_000;
+        int[] values = new int[partitionCount];
         for (int i = 0; i < values.length; i++)
             values[i] = i + 1;
         insertAndFlushTable(tableName, values);
@@ -96,12 +99,17 @@ public class RepairTokenRangeSplitterTest extends CQLTester
         Range<Token> tokenRange2 = range.next();
         Assert.assertFalse(range.hasNext());
 
-        Refs<SSTableReader> sstables1 = RepairTokenRangeSplitter.getSSTableReaderRefs(RepairType.FULL, KEYSPACE, tableName, tokenRange1);
-        Refs<SSTableReader> sstables2 = RepairTokenRangeSplitter.getSSTableReaderRefs(RepairType.FULL, KEYSPACE, tableName, tokenRange2);
-        SizeEstimate sizes1 = RepairTokenRangeSplitter.getSizesForRangeOfSSTables(RepairType.FULL, KEYSPACE, tableName, tokenRange1, sstables1);
-        SizeEstimate sizes2 = RepairTokenRangeSplitter.getSizesForRangeOfSSTables(RepairType.FULL, KEYSPACE, tableName, tokenRange2, sstables2);
-        // +-5% because HLL merge and the applying of range size approx ratio causes estimation errors
-        assertTrue(Math.abs(10000 - (sizes1.partitions + sizes2.partitions)) <= 60);
+        try(Refs<SSTableReader> sstables1 = RepairTokenRangeSplitter.getSSTableReaderRefs(RepairType.FULL, KEYSPACE, tableName, tokenRange1);
+            Refs<SSTableReader> sstables2 = RepairTokenRangeSplitter.getSSTableReaderRefs(RepairType.FULL, KEYSPACE, tableName, tokenRange2))
+        {
+            SizeEstimate sizes1 = RepairTokenRangeSplitter.getSizesForRangeOfSSTables(RepairType.FULL, KEYSPACE, tableName, tokenRange1, sstables1);
+            SizeEstimate sizes2 = RepairTokenRangeSplitter.getSizesForRangeOfSSTables(RepairType.FULL, KEYSPACE, tableName, tokenRange2, sstables2);
+
+            // +-5% because including entire compression blocks covering token range, HLL merge and the applying of range size approx ratio causes estimation errors
+            long allowableDelta = (long) (partitionCount * .05);
+            long estimatedPartitionDelta = Math.abs(partitionCount - (sizes1.partitions + sizes2.partitions));
+            assertTrue("Partition count delta was +/-" + estimatedPartitionDelta + " but expected +/- " + allowableDelta, estimatedPartitionDelta <= allowableDelta);
+        }
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitterTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitterTest.java
@@ -31,8 +31,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import org.apache.cassandra.config.DataStorageSpec.LongMebibytesBound;
 import org.apache.cassandra.config.DatabaseDescriptor;
@@ -58,7 +56,6 @@ import static org.junit.Assert.assertTrue;
 /**
  * Unit tests for {@link org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter}
  */
-@RunWith(Parameterized.class)
 public class RepairTokenRangeSplitterTest extends CQLTester
 {
     private RepairTokenRangeSplitter repairRangeSplitter;

--- a/test/unit/org/apache/cassandra/service/ActiveRepairServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/ActiveRepairServiceTest.java
@@ -1,21 +1,21 @@
 /*
-* Licensed to the Apache Software Foundation (ASF) under one
-* or more contributor license agreements.  See the NOTICE file
-* distributed with this work for additional information
-* regarding copyright ownership.  The ASF licenses this file
-* to you under the Apache License, Version 2.0 (the
-* "License"); you may not use this file except in compliance
-* with the License.  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.cassandra.service;
 
 import java.util.ArrayList;
@@ -39,6 +39,7 @@ import com.google.common.collect.Sets;
 import org.apache.cassandra.service.disk.usage.DiskUsageMonitor;
 import org.apache.cassandra.utils.TimeUUID;
 import org.apache.cassandra.utils.concurrent.Condition;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -233,7 +234,7 @@ public class ActiveRepairServiceTest
         }
 
         expected.remove(FBUtilities.getBroadcastAddressAndPort());
-        Collection<String> hosts = Arrays.asList(FBUtilities.getBroadcastAddressAndPort().getHostAddressAndPort(),expected.get(0).getHostAddressAndPort());
+        Collection<String> hosts = Arrays.asList(FBUtilities.getBroadcastAddressAndPort().getHostAddressAndPort(), expected.get(0).getHostAddressAndPort());
         Iterable<Range<Token>> ranges = StorageService.instance.getLocalReplicas(KEYSPACE5).ranges();
 
         assertEquals(expected.get(0), ActiveRepairService.getNeighbors(KEYSPACE5, ranges,
@@ -269,7 +270,6 @@ public class ActiveRepairServiceTest
         List<String> failed = StorageService.instance.getParentRepairStatus(3);
         assertNotNull(failed);
         assertEquals(ActiveRepairService.ParentRepairStatus.FAILED, ActiveRepairService.ParentRepairStatus.valueOf(failed.get(0)));
-
     }
 
     Set<InetAddressAndPort> addTokens(int max) throws Throwable
@@ -341,10 +341,10 @@ public class ActiveRepairServiceTest
     {
         assert params.length % 2 == 0 : "unbalanced key value pairs";
         Map<String, String> opt = new HashMap<>();
-        for (int i=0; i<(params.length >> 1); i++)
+        for (int i = 0; i < (params.length >> 1); i++)
         {
             int idx = i << 1;
-            opt.put(params[idx], params[idx+1]);
+            opt.put(params[idx], params[idx + 1]);
         }
         return RepairOption.parse(opt, DatabaseDescriptor.getPartitioner());
     }
@@ -376,7 +376,7 @@ public class ActiveRepairServiceTest
         Assert.assertNotEquals(UNREPAIRED_SSTABLE, getRepairedAt(opts(INCREMENTAL_KEY, b2s(true),
                                                                       FORCE_REPAIR_KEY, b2s(true)), false));
         Assert.assertEquals(UNREPAIRED_SSTABLE, getRepairedAt(opts(INCREMENTAL_KEY, b2s(true),
-                                                                      FORCE_REPAIR_KEY, b2s(true)), true));
+                                                                   FORCE_REPAIR_KEY, b2s(true)), true));
 
         // full repair
         Assert.assertEquals(UNREPAIRED_SSTABLE, getRepairedAt(opts(INCREMENTAL_KEY, b2s(false)), false));
@@ -422,7 +422,8 @@ public class ActiveRepairServiceTest
 
             // Submission is unblocked
             Thread.sleep(250);
-            validationExecutor.submit(() -> {});
+            validationExecutor.submit(() -> {
+            });
         }
         finally
         {
@@ -459,8 +460,8 @@ public class ActiveRepairServiceTest
             allSubmitted.await(TASK_SECONDS + 1, TimeUnit.SECONDS);
 
             // Give the tasks we expect to execute immediately chance to be scheduled
-            Util.spinAssertEquals(2 , ((ExecutorPlus) validationExecutor)::getActiveTaskCount, 1);
-            Util.spinAssertEquals(3 , ((ExecutorPlus) validationExecutor)::getPendingTaskCount, 1);
+            Util.spinAssertEquals(2, ((ExecutorPlus) validationExecutor)::getActiveTaskCount, 1);
+            Util.spinAssertEquals(3, ((ExecutorPlus) validationExecutor)::getPendingTaskCount, 1);
 
             // verify that we've reached a steady state with 2 threads actively processing and 3 queued tasks
             Assert.assertEquals(2, ((ExecutorPlus) validationExecutor).getActiveTaskCount());

--- a/test/unit/org/apache/cassandra/service/AutoRepairServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/AutoRepairServiceTest.java
@@ -52,6 +52,9 @@ import static org.apache.cassandra.config.CassandraRelevantProperties.SYSTEM_DIS
 import static org.junit.Assert.assertEquals;
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.service.AutoRepairService}
+ */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({ AutoRepairServiceTest.BasicTests.class, AutoRepairServiceTest.SetterTests.class })
 public class AutoRepairServiceTest

--- a/test/unit/org/apache/cassandra/service/AutoRepairServiceTest.java
+++ b/test/unit/org/apache/cassandra/service/AutoRepairServiceTest.java
@@ -97,7 +97,6 @@ public class AutoRepairServiceTest
             assertEquals(100, config.getAutoRepairHistoryClearDeleteHostsBufferInterval().toSeconds());
         }
 
-
         @Test
         public void testsetAutoRepairMaxRetriesCount()
         {
@@ -105,7 +104,6 @@ public class AutoRepairServiceTest
 
             assertEquals(101, config.getRepairMaxRetries());
         }
-
 
         @Test
         public void testsetAutoRepairRetryBackoffInSec()
@@ -181,7 +179,6 @@ public class AutoRepairServiceTest
         {
             return Arrays.asList(AutoRepairConfig.RepairType.values());
         }
-
 
         @BeforeClass
         public static void setupClass() throws Exception

--- a/test/unit/org/apache/cassandra/tools/nodetool/AutoRepairStatusTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/AutoRepairStatusTest.java
@@ -40,6 +40,9 @@ import static org.apache.cassandra.Util.setAutoRepairEnabled;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.tools.nodetool.AutoRepairStatus}
+ */
 @RunWith(Parameterized.class)
 public class AutoRepairStatusTest
 {
@@ -94,7 +97,7 @@ public class AutoRepairStatusTest
     @Test
     public void testExecute()
     {
-        when(probe.getOnGoingRepairHostIds(repairType.name())).thenReturn(ImmutableSet.of("host1", "host2", "host3", "host4"));
+        when(probe.getAutoRepairOnGoingRepairHostIds(repairType.name())).thenReturn(ImmutableSet.of("host1", "host2", "host3", "host4"));
         cmd.repairType = repairType.name();
 
         cmd.execute(probe);

--- a/test/unit/org/apache/cassandra/tools/nodetool/SSTableRepairedSetTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SSTableRepairedSetTest.java
@@ -39,6 +39,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.tools.nodetool.SSTableRepairedSetTest}
+ */
 public class SSTableRepairedSetTest
 {
     @Mock
@@ -58,8 +61,8 @@ public class SSTableRepairedSetTest
     public void testNoKeyspace() {
         when(probe.getNonLocalStrategyKeyspaces()).thenReturn(new ArrayList<>(Arrays.asList("ks1", "ks2")));
         when(probe.getKeyspaces()).thenReturn(new ArrayList<>(Arrays.asList("ks1", "ks2")));
-        when(probe.getTablesForKeyspace("ks1")).thenReturn(new ArrayList<>(Arrays.asList("table1", "table2")));
-        when(probe.getTablesForKeyspace("ks2")).thenReturn(new ArrayList<>(Arrays.asList("table3", "table4")));
+        when(probe.getAutoRepairTablesForKeyspace("ks1")).thenReturn(new ArrayList<>(Arrays.asList("table1", "table2")));
+        when(probe.getAutoRepairTablesForKeyspace("ks2")).thenReturn(new ArrayList<>(Arrays.asList("table3", "table4")));
         cmd.isRepaired = true;
         cmd.reallySet = true;
 

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetAutoRepairConfigTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetAutoRepairConfigTest.java
@@ -203,7 +203,6 @@ public class SetAutoRepairConfigTest
             verify(probe, times(1)).setAutoRepairThreads(repairType.name(), 1);
         }
 
-
         @Test
         public void testV2FlagMissing()
         {

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetAutoRepairConfigTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetAutoRepairConfigTest.java
@@ -45,6 +45,9 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+/**
+ * Unit tests for {@link org.apache.cassandra.tools.nodetool.SetAutoRepairConfig}
+ */
 @RunWith(Suite.class)
 @Suite.SuiteClasses({ SetAutoRepairConfigTest.NoParamTests.class, SetAutoRepairConfigTest.RepairTypeParamTests.class,
                       SetAutoRepairConfigTest.RepairTypeAndArgsParamsTests.class })
@@ -129,13 +132,13 @@ public class SetAutoRepairConfigTest
 
             cmd.execute(probe);
 
-            verify(probe, times(0)).startScheduler();
+            verify(probe, times(0)).startAutoRepairScheduler();
 
             cmd.args = ImmutableList.of("start_scheduler", "true");
 
             cmd.execute(probe);
 
-            verify(probe, times(1)).startScheduler();
+            verify(probe, times(1)).startAutoRepairScheduler();
         }
     }
 
@@ -186,7 +189,7 @@ public class SetAutoRepairConfigTest
             cmd.execute(probe);
 
             verify(out, times(1)).println("Auto-repair is not enabled");
-            verify(probe, times(0)).setRepairThreads(repairType.name(), 1);
+            verify(probe, times(0)).setAutoRepairThreads(repairType.name(), 1);
         }
 
         @Test
@@ -197,7 +200,7 @@ public class SetAutoRepairConfigTest
 
             cmd.execute(probe);
 
-            verify(probe, times(1)).setRepairThreads(repairType.name(), 1);
+            verify(probe, times(1)).setAutoRepairThreads(repairType.name(), 1);
         }
 
 
@@ -218,7 +221,7 @@ public class SetAutoRepairConfigTest
                 // expected
             }
 
-            verify(probe, times(0)).setRepairThreads(repairType.name(), 0);
+            verify(probe, times(0)).setAutoRepairThreads(repairType.name(), 0);
         }
 
         @Test(expected = IllegalArgumentException.class)
@@ -239,7 +242,7 @@ public class SetAutoRepairConfigTest
 
             cmd.execute(probe);
 
-            verify(probe, times(1)).setRepairPriorityForHosts(repairType.name(), commaSeparatedHostSet);
+            verify(probe, times(1)).setAutoRepairPriorityForHosts(repairType.name(), commaSeparatedHostSet);
         }
 
         @Test
@@ -251,7 +254,7 @@ public class SetAutoRepairConfigTest
 
             cmd.execute(probe);
 
-            verify(probe, times(1)).setForceRepairForHosts(repairType.name(), commaSeparatedHostSet);
+            verify(probe, times(1)).setAutoRepairForceRepairForHosts(repairType.name(), commaSeparatedHostSet);
         }
     }
 
@@ -275,14 +278,14 @@ public class SetAutoRepairConfigTest
         {
             return Stream.of(
             forEachRepairType("enabled", "true", (type) -> verify(probe, times(1)).setAutoRepairEnabled(type.name(), true)),
-            forEachRepairType("number_of_repair_threads", "1", (type) -> verify(probe, times(1)).setRepairThreads(type.name(), 1)),
-            forEachRepairType("min_repair_interval", "3h", (type) -> verify(probe, times(1)).setRepairMinInterval(type.name(), "3h")),
-            forEachRepairType("sstable_upper_threshold", "4", (type) -> verify(probe, times(1)).setRepairSSTableCountHigherThreshold(type.name(), 4)),
+            forEachRepairType("number_of_repair_threads", "1", (type) -> verify(probe, times(1)).setAutoRepairThreads(type.name(), 1)),
+            forEachRepairType("min_repair_interval", "3h", (type) -> verify(probe, times(1)).setAutoRepairMinInterval(type.name(), "3h")),
+            forEachRepairType("sstable_upper_threshold", "4", (type) -> verify(probe, times(1)).setAutoRepairSSTableCountHigherThreshold(type.name(), 4)),
             forEachRepairType("table_max_repair_time", "5s", (type) -> verify(probe, times(1)).setAutoRepairTableMaxRepairTime(type.name(), "5s")),
-            forEachRepairType("repair_primary_token_range_only", "true", (type) -> verify(probe, times(1)).setPrimaryTokenRangeOnly(type.name(), true)),
-            forEachRepairType("parallel_repair_count", "6", (type) -> verify(probe, times(1)).setParallelRepairCount(type.name(), 6)),
-            forEachRepairType("parallel_repair_percentage", "7", (type) -> verify(probe, times(1)).setParallelRepairPercentage(type.name(), 7)),
-            forEachRepairType("materialized_view_repair_enabled", "true", (type) -> verify(probe, times(1)).setMaterializedViewRepairEnabled(type.name(), true)),
+            forEachRepairType("repair_primary_token_range_only", "true", (type) -> verify(probe, times(1)).setAutoRepairPrimaryTokenRangeOnly(type.name(), true)),
+            forEachRepairType("parallel_repair_count", "6", (type) -> verify(probe, times(1)).setAutoRepairParallelRepairCount(type.name(), 6)),
+            forEachRepairType("parallel_repair_percentage", "7", (type) -> verify(probe, times(1)).setAutoRepairParallelRepairPercentage(type.name(), 7)),
+            forEachRepairType("materialized_view_repair_enabled", "true", (type) -> verify(probe, times(1)).setAutoRepairMaterializedViewRepairEnabled(type.name(), true)),
             forEachRepairType("ignore_dcs", "dc1,dc2", (type) -> verify(probe, times(1)).setAutoRepairIgnoreDCs(type.name(), ImmutableSet.of("dc1", "dc2"))),
             forEachRepairType("token_range_splitter.max_bytes_per_schedule", "500GiB", (type) -> verify(probe, times(1)).setAutoRepairTokenRangeSplitterParameter(type.name(), "max_bytes_per_schedule", "500GiB"))
             ).flatMap(Function.identity()).collect(Collectors.toList());


### PR DESCRIPTION
It covers the following changes from trunk version of cep-37
```
commit bf3a8e317ba5bc8a12f68f0038dc27edad6633b2 (HEAD -> trunk_cep_37, origin/trunk_cep_37)
Merge: 7c8ca46f1c f073777b4f
Author: jaydeepkumar1984 <chovatia.jaydeep@gmail.com>
Date:   Thu Feb 13 11:41:10 2025 -0800

    Merge pull request #37 from jaydeepkumar1984/trunk_cep_37_cr_feb_11_2025
    
    Additional review comments from Jaydeepkumar

commit f073777b4f96631011d05b5554b9f995d6506385 (origin/trunk_cep_37_cr_feb_11_2025, trunk_cep_37_cr_feb_11_2025)
Author: jaydeepkumar1984 <chovatia.jaydeep@gmail.com>
Date:   Thu Feb 13 11:32:43 2025 -0800

    Additional review comments from Andy

commit dfed69c116c5b6dc67f754d03d352c915ca215ce
Author: jaydeepkumar1984 <chovatia.jaydeep@gmail.com>
Date:   Tue Feb 11 17:04:09 2025 -0800

    Additional review comments from Jaydeepkumar

commit 7c8ca46f1c4248d15e921daf45535c9caa7899dc
Merge: bff0a97e9b 959f1f0c38
Author: jaydeepkumar1984 <chovatia.jaydeep@gmail.com>
Date:   Tue Feb 11 16:31:56 2025 -0800

    Merge pull request #35 from jaydeepkumar1984/trunk_cep_37_cr_feb_10_2025
    
    Fix review comments from Andy & Jaydeepkumar

commit 959f1f0c38fe81746dc28ade119501e314075db7 (origin/trunk_cep_37_cr_feb_10_2025, trunk_cep_37_cr_feb_10_2025)
Author: jaydeepkumar1984 <chovatia.jaydeep@gmail.com>
Date:   Tue Feb 11 15:34:20 2025 -0800

    Fix review comments from Andy

commit 427a680b2803d5618bb7d847a6386a29e16a0cf5
Author: jaydeepkumar1984 <chovatia.jaydeep@gmail.com>
Date:   Mon Feb 10 20:46:18 2025 -0800

    Fix review comments from Jaydeepkumar

commit 85d2cef327b7b446d91efcf5e68a455fa3aefd3f
Author: jaydeepkumar1984 <chovatia.jaydeep@gmail.com>
Date:   Mon Feb 10 15:59:30 2025 -0800

    Fix review comments from Andy

commit bff0a97e9b022b28f13bb7b2dab0ac70125e117f
Merge: 2578fecfed 20f34a8caa
Author: jaydeepkumar1984 <chovatia.jaydeep@gmail.com>
Date:   Tue Feb 11 09:15:14 2025 -0800

    Merge pull request #36 from tolbertam/CASSANDRA-20315
    
    Update RepairTokenRangeSplitter to work with BTI-formatted SSTables

commit 20f34a8caaa9e2af2bbc4f84555ba94250ea7e9e
Author: Andy Tolbert <6889771+tolbertam@users.noreply.github.com>
Date:   Mon Feb 10 19:58:51 2025 -0600

    Assert correct format selected

commit 2a45d1501538b449237e461bfa4e6a8b011bbecc
Author: Andy Tolbert <6889771+tolbertam@users.noreply.github.com>
Date:   Mon Feb 10 19:18:41 2025 -0600

    Test with Bti and Big format sstables

commit 66ad97225eeec45a7ecadea993a0aa38fd94fdae
Author: Andy Tolbert <6889771+tolbertam@users.noreply.github.com>
Date:   Mon Feb 10 19:04:19 2025 -0600

    Avoid possible division by zero

commit 39f0f9ea757e718153abe38679ab5c63e0870bcd
Author: Andy Tolbert <6889771+tolbertam@users.noreply.github.com>
Date:   Mon Feb 10 18:58:55 2025 -0600

    Update RepairTokenRangeSplitter to work with BTI-formatted SSTables
    
    While doing a review pass on the CEP-37 PR I realized that
    RepairTokenRangeSplitter could not possibly work with the new BTI
    sstable format introduced in 5.0 because it explicitly checks for
    BigTableReader implementations.
    
    In addition, the way it calculates the amount of bytes a range covers
    in an SSTable is big-format specific.
    
    I noticed that a new utility method
    SSTableReader.onDiskSizeForPartitionPositions was added recently in
    CASSANDRA-20092 that can effectively calculate this for us in an
    implementation-agnostic way.
    
    This change updates the code to use this method, and also remove any
    changes we previously made in SSTableScanner and BigTableScanner for
    this.
    
    Patch by Andy Tolbert; Reviewed by ___ for CASSANDRA-20315

```