### PR TITLE
Port CASSANDRA-20265: Fix race condition in auto-repair scheduler

### DIFF
--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -527,7 +527,7 @@ public class AutoRepair
         public void await(DurationSpec.IntSecondsBound repairSessionTimeout) throws InterruptedException
         {
             //if for some reason we don't hear back on repair progress for sometime
-            if (!condition.await(repairSessionTimeout.to(TimeUnit.SECONDS), TimeUnit.SECONDS))
+            if (!condition.await(repairSessionTimeout.toSeconds(), TimeUnit.SECONDS))
             {
                 success = false;
             }

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -20,6 +20,7 @@ package org.apache.cassandra.repair.autorepair;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -829,7 +830,7 @@ public class AutoRepairParameterizedTest extends CQLTester
     public void testSchedulerIgnoresErrorsFromUnrelatedRepairRunables()
     {
         RepairOption options = new RepairOption(RepairParallelism.PARALLEL, true, repairType == AutoRepairConfig.RepairType.INCREMENTAL, false,
-                                                AutoRepairService.instance.getAutoRepairConfig().getRepairThreads(repairType), Set.of(),
+                                                AutoRepairService.instance.getAutoRepairConfig().getRepairThreads(repairType), Collections.emptySet(),
                                                 false, false, false, PreviewKind.NONE, false, true, false, false, false);
         AutoRepairState repairState = AutoRepair.instance.repairStates.get(repairType);
         AutoRepairState spyState = spy(repairState);

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -920,6 +920,6 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepair.RepairProgressListener listener = new AutoRepair.RepairProgressListener(repairType);
         listener.progress("test", new ProgressEvent(ProgressEventType.COMPLETE, 0, 0, "test"));
 
-        listener.await();
+        listener.await(new DurationSpec.IntSecondsBound("12h"));
     }
 }

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairStateTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairStateTest.java
@@ -83,7 +83,8 @@ public class AutoRepairStateTest extends CQLTester
     }
 
     @Test
-    public void testGetLastRepairTime() {
+    public void testGetLastRepairTime()
+    {
         AutoRepairState state = RepairType.getAutoRepairState(repairType);
         state.lastRepairTimeInMs = 1;
 


### PR DESCRIPTION
Fixes a race condition inside the auto-repair scheduler which can cause a large buildup of active repair jobs.

The conditions for this race condition can be explained by the graph below:
![image](https://github.com/user-attachments/assets/6a84a770-8786-4c3a-b531-9c4ed804e813)

The auto-repair scheduler has a single progress listener object for all repair jobs it schedules. This means that the scheduler cannot differentiate between an event coming from job # 1 and an event coming from job # 2. It simply assumes that the event comes from the last repair job that the scheduler created. Such an assumption leads to a situation where:

1. The scheduler receives a failure from repair job # 1 and schedules repair job # 2 **(1)**

1. The scheduler then receives a 2nd failure from repair job # 1 and assumes that job # 2 failed even though it is still running **(2)**. Repair job # 3 is then scheduled.

1. Both repair job # 2 and repair job # 3 are running at the same time **(3)**

Most unit tests pass:
1) [j17_cqlshlib_cython_tests](https://app.circleci.com/pipelines/github/jaydeepkumar1984/cassandra/445/workflows/f13007fd-0ea6-4317-a2a3-61cc80a6c38c/jobs/44202)
2) [j17_cqlshlib_tests](https://app.circleci.com/pipelines/github/jaydeepkumar1984/cassandra/445/workflows/f13007fd-0ea6-4317-a2a3-61cc80a6c38c/jobs/44219)
3) [j17_unit_tests](https://app.circleci.com/pipelines/github/jaydeepkumar1984/cassandra/445/workflows/f13007fd-0ea6-4317-a2a3-61cc80a6c38c/jobs/44211)
4) [j17_utests_cdc](https://app.circleci.com/pipelines/github/jaydeepkumar1984/cassandra/445/workflows/f13007fd-0ea6-4317-a2a3-61cc80a6c38c/jobs/44215)
5) [j17_utests_fqltool](https://app.circleci.com/pipelines/github/jaydeepkumar1984/cassandra/445/workflows/f13007fd-0ea6-4317-a2a3-61cc80a6c38c/jobs/44200)
6) [j17_utests_latest](https://app.circleci.com/pipelines/github/jaydeepkumar1984/cassandra/445/workflows/f13007fd-0ea6-4317-a2a3-61cc80a6c38c/jobs/44212)
7) [j17_utests_long](https://app.circleci.com/pipelines/github/jaydeepkumar1984/cassandra/445/workflows/f13007fd-0ea6-4317-a2a3-61cc80a6c38c/jobs/44205)
8) [j17_utests_oa](https://app.circleci.com/pipelines/github/jaydeepkumar1984/cassandra/445/workflows/f13007fd-0ea6-4317-a2a3-61cc80a6c38c/jobs/44206)
9) [j17_utests_stress](https://app.circleci.com/pipelines/github/jaydeepkumar1984/cassandra/445/workflows/f13007fd-0ea6-4317-a2a3-61cc80a6c38c/jobs/44210)
10) [j17_utests_system_keyspace_directory](https://app.circleci.com/pipelines/github/jaydeepkumar1984/cassandra/445/workflows/f13007fd-0ea6-4317-a2a3-61cc80a6c38c/jobs/44209)
