### PR TITLE
Account for vnodes with repair_by_keyspace in RepairTokenRangeSplitter

### DIFF
--- a/src/java/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitter.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitter.java
@@ -340,7 +340,7 @@ public class RepairTokenRangeSplitter implements IAutoRepairTokenRangeSplitter
                     return 1;
                 }
                 return Long.compare(cfs1.metric.totalDiskSpaceUsed.getCount(), cfs2.metric.totalDiskSpaceUsed.getCount());
-            }).toList();
+            }).collect(Collectors.toList());
         }
 
         for (String tableName : tablesToProcess)

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -385,7 +385,7 @@ public class AutoRepairParameterizedTest extends CQLTester
         config.setMaterializedViewRepairEnabled(repairType, true);
 
         assertTrue(config.getMaterializedViewRepairEnabled(repairType));
-        assertEquals(List.of(MV), AutoRepairUtils.getAllMVs(repairType, keyspace, cfm));
+        assertEquals(Collections.singletonList(MV), AutoRepairUtils.getAllMVs(repairType, keyspace, cfm));
         config.setMaterializedViewRepairEnabled(repairType, false);
     }
 

--- a/test/unit/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitterTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/RepairTokenRangeSplitterTest.java
@@ -335,7 +335,7 @@ public class RepairTokenRangeSplitterTest extends CQLTester
     {
         AutoRepairService.instance.getAutoRepairConfig().setRepairByKeyspace(RepairType.FULL, true);
 
-        final KeyspaceRepairPlan repairPlan = new KeyspaceRepairPlan("system_auth", AuthKeyspace.TABLE_NAMES.stream().toList());
+        final KeyspaceRepairPlan repairPlan = new KeyspaceRepairPlan("system_auth", new ArrayList<>(AuthKeyspace.TABLE_NAMES));
         final PrioritizedRepairPlan prioritizedRepairPlan = new PrioritizedRepairPlan(0, List.of(repairPlan));
 
         Iterator<KeyspaceRepairAssignments> keyspaceAssignments = repairRangeSplitter.getRepairAssignments(true, List.of(prioritizedRepairPlan));
@@ -363,7 +363,7 @@ public class RepairTokenRangeSplitterTest extends CQLTester
     {
         AutoRepairService.instance.getAutoRepairConfig().setRepairByKeyspace(RepairType.FULL, false);
 
-        final KeyspaceRepairPlan repairPlan = new KeyspaceRepairPlan("system_auth", AuthKeyspace.TABLE_NAMES.stream().toList());
+        final KeyspaceRepairPlan repairPlan = new KeyspaceRepairPlan("system_auth", new ArrayList<>(AuthKeyspace.TABLE_NAMES));
         final PrioritizedRepairPlan prioritizedRepairPlan = new PrioritizedRepairPlan(0, List.of(repairPlan));
 
         Iterator<KeyspaceRepairAssignments> keyspaceAssignments = repairRangeSplitter.getRepairAssignments(true, List.of(prioritizedRepairPlan));


### PR DESCRIPTION
Updates RepairTokenRangeSplitter to call getRepairAssignmentsForKeyspace for each individual token range so repair_by_keyspace grouping works correctly.