### PR TITLE
Fix failing dtests: Ensure config has been initialized & use stats to confirm repair indeed ran

### DIFF
--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -89,7 +89,7 @@ public class AutoRepair
     protected final Map<AutoRepairConfig.RepairType, ScheduledExecutorPlus> repairRunnableExecutors;
 
     @VisibleForTesting
-    protected final Map<AutoRepairConfig.RepairType, AutoRepairState> repairStates;
+    public final Map<AutoRepairConfig.RepairType, AutoRepairState> repairStates;
 
     @VisibleForTesting
     // Auto-repair is likely to be run on multiple nodes independently, we want to avoid running multiple repair

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -84,12 +84,12 @@ public class AutoRepair
     public static DurationSpec.IntSecondsBound SLEEP_IF_REPAIR_FINISHES_QUICKLY = new DurationSpec.IntSecondsBound("5s");
 
     @VisibleForTesting
+    public final Map<AutoRepairConfig.RepairType, AutoRepairState> repairStates;
+
+    @VisibleForTesting
     protected final Map<AutoRepairConfig.RepairType, ScheduledExecutorPlus> repairExecutors;
 
     protected final Map<AutoRepairConfig.RepairType, ScheduledExecutorPlus> repairRunnableExecutors;
-
-    @VisibleForTesting
-    public final Map<AutoRepairConfig.RepairType, AutoRepairState> repairStates;
 
     @VisibleForTesting
     // Auto-repair is likely to be run on multiple nodes independently, we want to avoid running multiple repair

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -613,7 +613,8 @@ public final class SchemaKeyspace
 
         // As above, only add the auto_repair column if the scheduler is enabled
         // to avoid RTE in pre-5.1 versioned node during upgrades
-        if (DatabaseDescriptor.getRawConfig() != null && DatabaseDescriptor.getAutoRepairConfig().isAutoRepairSchedulingEnabled())
+        if (DatabaseDescriptor.getRawConfig() != null
+            && DatabaseDescriptor.getAutoRepairConfig().isAutoRepairSchedulingEnabled())
         {
             builder.add("auto_repair", params.autoRepair.asMap());
         }

--- a/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
+++ b/src/java/org/apache/cassandra/schema/SchemaKeyspace.java
@@ -613,7 +613,7 @@ public final class SchemaKeyspace
 
         // As above, only add the auto_repair column if the scheduler is enabled
         // to avoid RTE in pre-5.1 versioned node during upgrades
-        if (DatabaseDescriptor.getAutoRepairConfig().isAutoRepairSchedulingEnabled())
+        if (DatabaseDescriptor.getRawConfig() != null && DatabaseDescriptor.getAutoRepairConfig().isAutoRepairSchedulingEnabled())
         {
             builder.add("auto_repair", params.autoRepair.asMap());
         }

--- a/src/java/org/apache/cassandra/schema/TableParams.java
+++ b/src/java/org/apache/cassandra/schema/TableParams.java
@@ -351,7 +351,9 @@ public final class TableParams
                .append("AND read_repair = ").appendWithSingleQuotes(readRepair.toString())
                .newLine()
                .append("AND speculative_retry = ").appendWithSingleQuotes(speculativeRetry.toString());
-        if (DatabaseDescriptor.getRawConfig() != null && DatabaseDescriptor.getAutoRepairConfig().isAutoRepairSchedulingEnabled())
+
+        if (DatabaseDescriptor.getRawConfig() != null
+            && DatabaseDescriptor.getAutoRepairConfig().isAutoRepairSchedulingEnabled())
         {
             builder.newLine()
                 .append("AND auto_repair = ").append(autoRepair.asMap());

--- a/src/java/org/apache/cassandra/schema/TableParams.java
+++ b/src/java/org/apache/cassandra/schema/TableParams.java
@@ -351,7 +351,7 @@ public final class TableParams
                .append("AND read_repair = ").appendWithSingleQuotes(readRepair.toString())
                .newLine()
                .append("AND speculative_retry = ").appendWithSingleQuotes(speculativeRetry.toString());
-        if (DatabaseDescriptor.getAutoRepairConfig().isAutoRepairSchedulingEnabled())
+        if (DatabaseDescriptor.getRawConfig() != null && DatabaseDescriptor.getAutoRepairConfig().isAutoRepairSchedulingEnabled())
         {
             builder.newLine()
                 .append("AND auto_repair = ").append(autoRepair.asMap());

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
@@ -114,9 +114,14 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
         cluster.forEach(i -> i.runOnInstance(() -> {
             try
             {
-                Util.spinAssert("AutoRepair has not yet completed one repair cycle",
+                Util.spinAssert("AutoRepair has not yet completed one FULL repair cycle",
                                 greaterThan(0L),
                                 AutoRepair.instance.repairStates.get(AutoRepairConfig.RepairType.FULL)::getLastRepairTime,
+                                5,
+                                TimeUnit.MINUTES);
+                Util.spinAssert("AutoRepair has not yet completed one INCREMENTAL repair cycle",
+                                greaterThan(0L),
+                                AutoRepair.instance.repairStates.get(AutoRepairConfig.RepairType.INCREMENTAL)::getLastRepairTime,
                                 5,
                                 TimeUnit.MINUTES);
             }

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
@@ -112,23 +112,16 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
 
         // validate that the repair ran on all nodes
         cluster.forEach(i -> i.runOnInstance(() -> {
-            try
-            {
-                Util.spinAssert("AutoRepair has not yet completed one FULL repair cycle",
-                                greaterThan(0L),
-                                AutoRepair.instance.repairStates.get(AutoRepairConfig.RepairType.FULL)::getLastRepairTime,
-                                5,
-                                TimeUnit.MINUTES);
-                Util.spinAssert("AutoRepair has not yet completed one INCREMENTAL repair cycle",
-                                greaterThan(0L),
-                                AutoRepair.instance.repairStates.get(AutoRepairConfig.RepairType.INCREMENTAL)::getLastRepairTime,
-                                5,
-                                TimeUnit.MINUTES);
-            }
-            catch (Exception e)
-            {
-                throw new RuntimeException(e);
-            }
+            Util.spinAssert("AutoRepair has not yet completed one FULL repair cycle",
+                            greaterThan(0L),
+                            AutoRepair.instance.repairStates.get(AutoRepairConfig.RepairType.FULL)::getLastRepairTime,
+                            5,
+                            TimeUnit.MINUTES);
+            Util.spinAssert("AutoRepair has not yet completed one INCREMENTAL repair cycle",
+                            greaterThan(0L),
+                            AutoRepair.instance.repairStates.get(AutoRepairConfig.RepairType.INCREMENTAL)::getLastRepairTime,
+                            5,
+                            TimeUnit.MINUTES);
         }));
         validate(AutoRepairConfig.RepairType.FULL.toString());
         validate(AutoRepairConfig.RepairType.INCREMENTAL.toString());

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
@@ -22,9 +22,11 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.ImmutableMap;
 
+import org.apache.cassandra.Util;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.schema.SystemDistributedKeyspace;
 
@@ -40,6 +42,7 @@ import org.apache.cassandra.repair.autorepair.AutoRepairConfig;
 import org.apache.cassandra.service.AutoRepairService;
 
 import static org.apache.cassandra.schema.SchemaConstants.DISTRIBUTED_KEYSPACE_NAME;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -111,23 +114,11 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
         cluster.forEach(i -> i.runOnInstance(() -> {
             try
             {
-                while(true)
-                {
-                    if (AutoRepair.instance.repairStates.get(AutoRepairConfig.RepairType.FULL).getLastRepairTime() == 0
-                        || AutoRepair.instance.repairStates.get(AutoRepairConfig.RepairType.INCREMENTAL).getLastRepairTime() == 0)
-                    {
-                        try
-                        {
-                            Thread.sleep(5000);
-                        }
-                        catch (InterruptedException e)
-                        {
-                            throw new RuntimeException(e);
-                        }
-                        continue;
-                    }
-                    break;
-                }
+                Util.spinAssert("AutoRepair has not yet completed one repair cycle",
+                                greaterThan(0L),
+                                AutoRepair.instance.repairStates.get(AutoRepairConfig.RepairType.FULL)::getLastRepairTime,
+                                5,
+                                TimeUnit.MINUTES);
             }
             catch (Exception e)
             {

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
@@ -21,13 +21,13 @@ package org.apache.cassandra.distributed.test.repair;
 import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.concurrent.TimeUnit;
 import java.util.UUID;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.Uninterruptibles;
+
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.schema.SystemDistributedKeyspace;
+
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -63,19 +63,19 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
                                                              ImmutableMap.of(
                                                              "repair_type_overrides",
                                                              ImmutableMap.of(AutoRepairConfig.RepairType.FULL.getConfigName(),
-                                                                                 ImmutableMap.of(
-                                                                                 "initial_scheduler_delay", "5s",
-                                                                                 "enabled", "true",
-                                                                                 "parallel_repair_count", "1",
-                                                                                 "parallel_repair_percentage", "0",
-                                                                                 "min_repair_interval", "1s"),
+                                                                             ImmutableMap.of(
+                                                                             "initial_scheduler_delay", "5s",
+                                                                             "enabled", "true",
+                                                                             "parallel_repair_count", "1",
+                                                                             "parallel_repair_percentage", "0",
+                                                                             "min_repair_interval", "1s"),
                                                                              AutoRepairConfig.RepairType.INCREMENTAL.getConfigName(),
-                                                                                 ImmutableMap.of(
-                                                                                 "initial_scheduler_delay", "5s",
-                                                                                 "enabled", "true",
-                                                                                 "parallel_repair_count", "1",
-                                                                                 "parallel_repair_percentage", "0",
-                                                                                 "min_repair_interval", "1s"))))
+                                                                             ImmutableMap.of(
+                                                                             "initial_scheduler_delay", "5s",
+                                                                             "enabled", "true",
+                                                                             "parallel_repair_count", "1",
+                                                                             "parallel_repair_percentage", "0",
+                                                                             "min_repair_interval", "1s"))))
                                                         .set("auto_repair.enabled", "true")
                                                         .set("auto_repair.global_settings.repair_by_keyspace", "true")
                                                         .set("auto_repair.repair_task_min_duration", "0s")
@@ -106,9 +106,34 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
                 throw new RuntimeException(e);
             }
         }));
-        // wait for a couple of minutes for repair to go through on all three nodes
-        Uninterruptibles.sleepUninterruptibly(2, TimeUnit.MINUTES);
 
+        // validate that the repair ran on all nodes
+        cluster.forEach(i -> i.runOnInstance(() -> {
+            try
+            {
+                while(true)
+                {
+                    if (AutoRepair.instance.repairStates.get(AutoRepairConfig.RepairType.FULL).getLastRepairTime() == 0
+                        || AutoRepair.instance.repairStates.get(AutoRepairConfig.RepairType.INCREMENTAL).getLastRepairTime() == 0)
+                    {
+                        try
+                        {
+                            Thread.sleep(5000);
+                        }
+                        catch (InterruptedException e)
+                        {
+                            throw new RuntimeException(e);
+                        }
+                        continue;
+                    }
+                    break;
+                }
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException(e);
+            }
+        }));
         validate(AutoRepairConfig.RepairType.FULL.toString());
         validate(AutoRepairConfig.RepairType.INCREMENTAL.toString());
     }


### PR DESCRIPTION
**Problem-1**
```
Caused by: java.lang.NullPointerException at org.apache.cassandra.config.DatabaseDescriptor.getAutoRepairConfig(DatabaseDescriptor.java:5555) at org.apache.cassandra.schema.TableParams.appendCqlTo(TableParams.java:354) at org.apache.cassandra.schema.TableMetadata.appendTableOptions(TableMetadata.java:1566) at org.apache.cassandra.schema.TableMetadata.appendCqlTo(TableMetadata.java:1461) at org.apache.cassandra.schema.TableMetadata.toCqlString(TableMetadata.java:1406) at org.apache.cassandra.distributed.test.cql3.StatefulASTBase$BaseState.createTable(StatefulASTBase.java:250) at org.apache.cassandra.distributed.test.cql3.StatefulASTBase$BaseState. (StatefulASTBase.java:237) at org.apache.cassandra.distributed.test.cql3.StatefulASTBase$CommonState. (StatefulASTBase.java:465) at org.apache.cassandra.distributed.test.cql3.SingleNodeTableWalkTest$State. (SingleNodeTableWalkTest.java:399) at org.apache.cassandra.distributed.test.cql3.MultiNodeTableWalkBase$MultiNodeState. (MultiNodeTableWalkBase.java:74) at org.apache.cassandra.distributed.test.cql3.MultiNodeTableWalkBase.createState(MultiNodeTableWalkBase.java:67) at org.apache.cassandra.distributed.test.cql3.SingleNodeTableWalkTest.lambda$test$5(SingleNodeTableWalkTest.java:336) at accord.utils.Property$StatefulBuilder.check(Property.java:454)

```

Fix: There are newly added InJVM dtests, in that the main Config object might not have been initialized when TableParams.java is invoked. As part of CEP-37, we are conditionally appending the //auto_repair//  field based on the config. 
Add a safeguard to check if the config has been initialized or not.

**Problem-2**
```
junit.framework.AssertionFailedError at org.apache.cassandra.distributed.test.repair.AutoRepairSchedulerTest.validate(AutoRepairSchedulerTest.java:131) at org.apache.cassandra.distributed.test.repair.AutoRepairSchedulerTest.testScheduler(AutoRepairSchedulerTest.java:112) at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) 
```

Fix: The test is flaky as it uses sleep to ensure the background repair job ran. This causes flakiness, so use the AutoRepair stat *lastReparTime* to ensure that one cycle has indeed finished.

https://issues.apache.org/jira/browse/CASSANDRA-20413

