### PR TITLE
Avoid micros splitting of token ranges for FixedSplitTokenRangeSplitter

### DIFF
--- a/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
@@ -46,6 +46,17 @@ public class FixedSplitTokenRangeSplitter implements IAutoRepairTokenRangeSplitt
     private static final Logger logger = LoggerFactory.getLogger(FixedSplitTokenRangeSplitter.class);
 
     /**
+     * Selecting the default value is tricky. If we select a small number then individual repair would be heavy,
+     * on the other hand, if we select large then too many repair sessions would be created.
+     * <p>
+     * The default 64 is a good number for non v-nodes, but with v-nodes it can result in too many repair sessions
+     * because the number of repair sessions on a node =  number_of_subranges * num_token.
+     * <p>
+     * To keep it balances, 32 serves a good default that would cater to both v-nodes and non v-nodes.
+     */
+    public static final int DEFAULT_SUBRANGES = 32;
+
+    /**
      * The number of subranges to split each to-be-repaired token range into. Defaults to 1.
      * <p>
      * The higher this number, the smaller the repair sessions will be.
@@ -69,7 +80,7 @@ public class FixedSplitTokenRangeSplitter implements IAutoRepairTokenRangeSplitt
     {
         this.repairType = repairType;
 
-        numberOfSubranges = Integer.parseInt(parameters.getOrDefault(NUMBER_OF_SUBRANGES, "1"));
+        numberOfSubranges = Integer.parseInt(parameters.getOrDefault(NUMBER_OF_SUBRANGES, Integer.toString(DEFAULT_SUBRANGES)));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
@@ -49,8 +49,8 @@ public class FixedSplitTokenRangeSplitter implements IAutoRepairTokenRangeSplitt
      * Selecting the default value is tricky. If we select a small number, individual repairs would be heavy.
      * On the other hand, if we select a large number, too many repair sessions would be created.
      * <p>
-     * The default value of 64 works well for non-vnodes, but with vnodes, it might result in too many repair sessions
-     * and to cap the number for vnodes, we use the following formula:
+     * If vnodes are configured using <code>num_tokens</code>, attempts to evenly subdivide subranges by each range
+     * using the following formula:
      * <p>
      *      Math.max(1, numberOfSubranges / tokens.size())
      * <p>
@@ -59,19 +59,12 @@ public class FixedSplitTokenRangeSplitter implements IAutoRepairTokenRangeSplitt
     public static final int DEFAULT_NUMBER_OF_SUBRANGES = 32;
 
     /**
-     * The number of subranges to split each to-be-repaired token range into. Defaults to 1.
+     * Number of evenly split subranges to create for each node that repair runs for.
      * <p>
-     * The higher this number, the smaller the repair sessions will be.
-     * <p>
-     * If you are using vnodes, say 256, then the repair will always go one vnode range at a time.  This parameter,
-     * additionally, will let us further subdivide a given vnode range into subranges.
-     * <p>
-     * With the value "1" and vnodes of 256, a given table on a node will undergo the repair 256 times. But with a
-     * value "2", the same table on a node will undergo a repair 512 times because every vnode range will be further
-     * divided by two.
-     * <p>
-     * If you do not use vnodes or the number of vnodes is pretty small, say 8, setting this value to a higher number,
-     * such as 16, will be useful to repair on a smaller range, and the chance of succeeding is higher.
+     * If vnodes are configured using <code>num_tokens</code>, attempts to evenly subdivide subranges by each range.
+     * For example, for <code>num_tokens: 16</code> and <code>number_of_subranges: 32</code>, <code>2 (32/16)</code>
+     * repair assignments will be created for each token range.  At least one repair assignment will be
+     * created for each token range.
      */
     static final String NUMBER_OF_SUBRANGES = "number_of_subranges";
 

--- a/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
@@ -54,7 +54,7 @@ public class FixedSplitTokenRangeSplitter implements IAutoRepairTokenRangeSplitt
      * <p>
      * To keep it balances, 32 serves a good default that would cater to both v-nodes and non v-nodes.
      */
-    public static final int DEFAULT_SUBRANGES = 32;
+    public static final int DEFAULT_NUMBER_OF_SUBRANGES = 32;
 
     /**
      * The number of subranges to split each to-be-repaired token range into. Defaults to 1.
@@ -80,7 +80,7 @@ public class FixedSplitTokenRangeSplitter implements IAutoRepairTokenRangeSplitt
     {
         this.repairType = repairType;
 
-        numberOfSubranges = Integer.parseInt(parameters.getOrDefault(NUMBER_OF_SUBRANGES, Integer.toString(DEFAULT_SUBRANGES)));
+        numberOfSubranges = Integer.parseInt(parameters.getOrDefault(NUMBER_OF_SUBRANGES, Integer.toString(DEFAULT_NUMBER_OF_SUBRANGES)));
     }
 
     @Override

--- a/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
@@ -102,9 +102,11 @@ public class FixedSplitTokenRangeSplitter implements IAutoRepairTokenRangeSplitt
         boolean byKeyspace = config.getRepairByKeyspace(repairType);
         // collect all token ranges.
         List<Range<Token>> allRanges = new ArrayList<>();
+        // this is done to avoid micro splits in the case of vnodes
+        int splitsPerRange = Math.max(1, numberOfSubranges / tokens.size());
         for (Range<Token> token : tokens)
         {
-            allRanges.addAll(split(token, numberOfSubranges));
+            allRanges.addAll(split(token, splitsPerRange));
         }
 
         if (byKeyspace)

--- a/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
@@ -49,10 +49,10 @@ public class FixedSplitTokenRangeSplitter implements IAutoRepairTokenRangeSplitt
      * Selecting the default value is tricky. If we select a small number, individual repairs would be heavy.
      * On the other hand, if we select a large number, too many repair sessions would be created.
      * <p>
-     * The default value of 64 works well for non-vnodes, but with vnodes, it can result in too many repair sessions
-     * because the total number of repair sessions on a node is calculated as:
+     * The default value of 64 works well for non-vnodes, but with vnodes, it might result in too many repair sessions
+     * and to cap the number for vnodes, we use the following formula:
      * <p>
-     *      number_of_subranges * num_token
+     *      Math.max(1, numberOfSubranges / tokens.size())
      * <p>
      * To maintain balance, 32 serves as a good default that accommodates both vnodes and non-vnodes effectively.
      */

--- a/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitter.java
@@ -46,13 +46,15 @@ public class FixedSplitTokenRangeSplitter implements IAutoRepairTokenRangeSplitt
     private static final Logger logger = LoggerFactory.getLogger(FixedSplitTokenRangeSplitter.class);
 
     /**
-     * Selecting the default value is tricky. If we select a small number then individual repair would be heavy,
-     * on the other hand, if we select large then too many repair sessions would be created.
+     * Selecting the default value is tricky. If we select a small number, individual repairs would be heavy.
+     * On the other hand, if we select a large number, too many repair sessions would be created.
      * <p>
-     * The default 64 is a good number for non v-nodes, but with v-nodes it can result in too many repair sessions
-     * because the number of repair sessions on a node =  number_of_subranges * num_token.
+     * The default value of 64 works well for non-vnodes, but with vnodes, it can result in too many repair sessions
+     * because the total number of repair sessions on a node is calculated as:
      * <p>
-     * To keep it balances, 32 serves a good default that would cater to both v-nodes and non v-nodes.
+     *      number_of_subranges * num_token
+     * <p>
+     * To maintain balance, 32 serves as a good default that accommodates both vnodes and non-vnodes effectively.
      */
     public static final int DEFAULT_NUMBER_OF_SUBRANGES = 32;
 

--- a/src/java/org/apache/cassandra/service/AutoRepairService.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairService.java
@@ -255,6 +255,12 @@ public class AutoRepairService implements AutoRepairServiceMBean
         config.getTokenRangeSplitterInstance(RepairType.parse(repairType)).setParameter(key, value);
     }
 
+    @Override
+    public void setRepairByKeyspace(String repairType, boolean repairByKeyspace)
+    {
+        config.setRepairByKeyspace(RepairType.parse(repairType), repairByKeyspace);
+    }
+
     private String formatRepairTypeConfig(RepairType repairType, AutoRepairConfig config)
     {
         StringBuilder sb = new StringBuilder();

--- a/src/java/org/apache/cassandra/service/AutoRepairServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairServiceMBean.java
@@ -68,4 +68,7 @@ public interface AutoRepairServiceMBean
     public Set<String> getOnGoingRepairHostIds(String repairType);
 
     public void setAutoRepairTokenRangeSplitterParameter(String repairType, String key, String value);
+
+    public void setRepairByKeyspace(String repairType, boolean repairByKeyspace);
+
 }

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -2642,6 +2642,11 @@ public class NodeProbe implements AutoCloseable
     {
         return autoRepairProxy.getOnGoingRepairHostIds(repairType);
     }
+
+    public void setAutoRepairRepairByKeyspace(String repairType, boolean enabled)
+    {
+        autoRepairProxy.setRepairByKeyspace(repairType, enabled);
+    }
 }
 
 class ColumnFamilyStoreMBeanIterator implements Iterator<Map.Entry<String, ColumnFamilyStoreMBean>>

--- a/src/java/org/apache/cassandra/tools/nodetool/SetAutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/SetAutoRepairConfig.java
@@ -48,7 +48,8 @@ public class SetAutoRepairConfig extends NodeToolCmd
                   "|enabled|table_max_repair_time|priority_hosts|forcerepair_hosts|ignore_dcs" +
                   "|history_clear_delete_hosts_buffer_interval|repair_primary_token_range_only" +
                   "|parallel_repair_count|parallel_repair_percentage|materialized_view_repair_enabled|repair_max_retries" +
-                  "|repair_retry_backoff|repair_session_timeout|min_repair_task_duration|token_range_splitter.<property>]",
+                  "|repair_retry_backoff|repair_session_timeout|min_repair_task_duration" +
+                  "|repair_by_keyspace|token_range_splitter.<property>]",
     required = true)
     protected List<String> args = new ArrayList<>();
 
@@ -158,6 +159,9 @@ public class SetAutoRepairConfig extends NodeToolCmd
                 break;
             case "repair_session_timeout":
                 probe.setAutoRepairSessionTimeout(repairTypeStr, paramVal);
+                break;
+            case "repair_by_keyspace":
+                probe.setAutoRepairRepairByKeyspace(repairTypeStr, Boolean.parseBoolean(paramVal));
                 break;
             default:
                 throw new IllegalArgumentException("Unknown parameter: " + paramType);

--- a/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterHelper.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterHelper.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Helper class for for {@link FixedSplitTokenRangeSplitterNoVNodesTest} and {@link FixedSplitTokenRangeSplitterVNodesTest}
+ * Helper class for {@link FixedSplitTokenRangeSplitterNoVNodesTest} and {@link FixedSplitTokenRangeSplitterVNodesTest}
  */
 public class FixedSplitTokenRangeSplitterHelper
 {
@@ -111,7 +111,7 @@ public class FixedSplitTokenRangeSplitterHelper
             List<Range<Token>> expectedTokensForATable = new ArrayList<>();
             for (int j = 0; j < assignmentsPerTable; j++)
             {
-                assertEquals(Arrays.asList(tables.get(i)), assignments.get(i * assignmentsPerTable + j).getTableNames());
+                assertEquals(Collections.singletonList(tables.get(i)), assignments.get(i * assignmentsPerTable + j).getTableNames());
                 assignmentForATable.add(assignments.get(i * assignmentsPerTable + j));
                 expectedTokensForATable.add(expectedToken.get(i * assignmentsPerTable + j));
             }
@@ -125,7 +125,6 @@ public class FixedSplitTokenRangeSplitterHelper
         AutoRepairService.instance.getAutoRepairConfig().setRepairByKeyspace(repairType, true);
         Collection<Range<Token>> tokens = StorageService.instance.getPrimaryRanges(KEYSPACE);
         assertEquals(numTokens, tokens.size());
-        List<String> tables = Arrays.asList(TABLE1, TABLE2, TABLE3);
         List<Range<Token>> expectedToken = new ArrayList<>();
         for (Range<Token> range : tokens)
         {
@@ -151,7 +150,7 @@ public class FixedSplitTokenRangeSplitterHelper
         compare(numTokens, numberOfSplits, expectedToken, assignments);
     }
 
-    public static void testTokenRangesWithDefaultSplit(int numTokens, int numberOfSubRanges, AutoRepairConfig.RepairType repairType)
+    public static void testTokenRangesWithDefaultSplit(int numTokens, AutoRepairConfig.RepairType repairType)
     {
         int numberOfSplits = calcSplits(numTokens, DEFAULT_NUMBER_OF_SUBRANGES);
         Collection<Range<Token>> tokens = StorageService.instance.getPrimaryRanges(KEYSPACE);

--- a/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterHelper.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterHelper.java
@@ -27,92 +27,34 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import org.apache.cassandra.ServerTestUtils;
-import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.QueryProcessor;
-import org.apache.cassandra.dht.BootStrapper;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
-import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.service.AutoRepairService;
 import org.apache.cassandra.service.StorageService;
-import org.apache.cassandra.tcm.ClusterMetadata;
 
-import static org.apache.cassandra.config.CassandraRelevantProperties.SYSTEM_DISTRIBUTED_DEFAULT_RF;
-import static org.apache.cassandra.cql3.CQLTester.Fuzzed.setupSeed;
-import static org.apache.cassandra.cql3.CQLTester.Fuzzed.updateConfigs;
-import static org.apache.cassandra.repair.autorepair.FixedSplitTokenRangeSplitter.DEFAULT_SUBRANGES;
+import static org.apache.cassandra.repair.autorepair.FixedSplitTokenRangeSplitter.DEFAULT_NUMBER_OF_SUBRANGES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Unit tests for {@link org.apache.cassandra.repair.autorepair.FixedSplitTokenRangeSplitter}
+ * Helper class for for {@link FixedSplitTokenRangeSplitterNoVNodesTest} and {@link FixedSplitTokenRangeSplitterVNodesTest}
  */
 @RunWith(Parameterized.class)
-public class FixedSplitTokenRangeSplitterTest
+public class FixedSplitTokenRangeSplitterHelper
 {
-    private static final String KEYSPACE = "ks";
     private static final String TABLE1 = "tbl1";
     private static final String TABLE2 = "tbl2";
     private static final String TABLE3 = "tbl3";
+    public static final String KEYSPACE = "ks";
 
-    @Parameterized.Parameter(0)
-    public AutoRepairConfig.RepairType repairType;
-
-    @Parameterized.Parameter(1)
-    public int numberOfSubRanges;
-
-    @Parameterized.Parameter(2)
-    public int numTokens;
-
-    public static final int curTokenRange = 1;
-
-    @Parameterized.Parameters(name = "repairType={0}, numberOfSubRanges={1}, numTokens={2}")
-    public static Collection<Object[]> parameters()
+    public static void testTokenRangesSplitByTable(int numTokens, int numberOfSubRanges, AutoRepairConfig.RepairType repairType)
     {
-        List<Object[]> params = new ArrayList<>();
-        for (AutoRepairConfig.RepairType type : AutoRepairConfig.RepairType.values())
-        {
-            for (int subRange : Arrays.asList(1, 2, 4, 8, 16, 32, 64, 128, 256))
-            {
-                for (int numToken : Arrays.asList(curTokenRange))
-                {
-                    params.add(new Object[]{ type, subRange, numToken });
-                }
-            }
-        }
-        return params;
-    }
-
-    @BeforeClass
-    public static void setupClass() throws Exception
-    {
-        setupSeed();
-        updateConfigs();
-        DatabaseDescriptor.setPartitioner("org.apache.cassandra.dht.Murmur3Partitioner");
-        ServerTestUtils.prepareServerNoRegister();
-
-        Set<Token> tokens1 = BootStrapper.getRandomTokens(ClusterMetadata.current(), curTokenRange);
-        ServerTestUtils.registerLocal(tokens1);
-        // Ensure that the on-disk format statics are loaded before the test run
-        Version.LATEST.onDiskFormat();
-        StorageService.instance.doAutoRepairSetup();
-
-        SYSTEM_DISTRIBUTED_DEFAULT_RF.setInt(1);
-        QueryProcessor.executeInternal(String.format("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}", KEYSPACE));
-    }
-
-    @Test
-    public void testTokenRangesSplitByTable()
-    {
-        int numberOfSplits = calcSplits(numberOfSubRanges);
+        int numberOfSplits = calcSplits(numTokens, numberOfSubRanges);
         AutoRepairService.instance.getAutoRepairConfig().setRepairByKeyspace(repairType, false);
         Collection<Range<Token>> tokens = StorageService.instance.getPrimaryRanges(KEYSPACE);
         assertEquals(numTokens, tokens.size());
@@ -147,18 +89,17 @@ public class FixedSplitTokenRangeSplitterTest
             List<Range<Token>> expectedTokensForATable = new ArrayList<>();
             for (int j = 0; j < assignmentsPerTable; j++)
             {
-                assertEquals(Arrays.asList(tables.get(i)), assignments.get(i*assignmentsPerTable + j).getTableNames());
-                assignmentForATable.add(assignments.get(i*assignmentsPerTable+j));
-                expectedTokensForATable.add(expectedToken.get(i*assignmentsPerTable+j));
+                assertEquals(Arrays.asList(tables.get(i)), assignments.get(i * assignmentsPerTable + j).getTableNames());
+                assignmentForATable.add(assignments.get(i * assignmentsPerTable + j));
+                expectedTokensForATable.add(expectedToken.get(i * assignmentsPerTable + j));
             }
-            compare(numberOfSplits, expectedTokensForATable, assignmentForATable);
+            compare(numTokens, numberOfSplits, expectedTokensForATable, assignmentForATable);
         }
     }
 
-    @Test
-    public void testTokenRangesSplitByKeyspace()
+    public static void testTokenRangesSplitByKeyspace(int numTokens, int numberOfSubRanges, AutoRepairConfig.RepairType repairType)
     {
-        int numberOfSplits = calcSplits(numberOfSubRanges);
+        int numberOfSplits = calcSplits(numTokens, numberOfSubRanges);
         AutoRepairService.instance.getAutoRepairConfig().setRepairByKeyspace(repairType, true);
         Collection<Range<Token>> tokens = StorageService.instance.getPrimaryRanges(KEYSPACE);
         assertEquals(numTokens, tokens.size());
@@ -185,13 +126,12 @@ public class FixedSplitTokenRangeSplitterTest
         assertEquals(numTokens * numberOfSplits, assignments.size());
         assertEquals(expectedToken.size(), assignments.size());
 
-        compare(numberOfSplits, expectedToken, assignments);
+        compare(numTokens, numberOfSplits, expectedToken, assignments);
     }
 
-    @Test
-    public void testTokenRangesWithDefaultSplit()
+    public static void testTokenRangesWithDefaultSplit(int numTokens, int numberOfSubRanges, AutoRepairConfig.RepairType repairType)
     {
-        int numberOfSplits = calcSplits(DEFAULT_SUBRANGES);
+        int numberOfSplits = calcSplits(numTokens, DEFAULT_NUMBER_OF_SUBRANGES);
         Collection<Range<Token>> tokens = StorageService.instance.getPrimaryRanges(KEYSPACE);
         assertEquals(numTokens, tokens.size());
         List<Range<Token>> expectedToken = new ArrayList<>();
@@ -215,10 +155,10 @@ public class FixedSplitTokenRangeSplitterTest
         // should be 3 entries for the table which covers each token range.
         assertEquals(numTokens * numberOfSplits, assignments.size());
 
-        compare(numberOfSplits, expectedToken, assignments);
+        compare(numTokens, numberOfSplits, expectedToken, assignments);
     }
 
-    private void compare(int numberOfSplits, List<Range<Token>> expectedToken, List<RepairAssignment> assignments)
+    private static void compare(int numTokens, int numberOfSplits, List<Range<Token>> expectedToken, List<RepairAssignment> assignments)
     {
         assertEquals(expectedToken.size(), assignments.size());
         Set<Range<Token>> a = new TreeSet<>();
@@ -231,7 +171,7 @@ public class FixedSplitTokenRangeSplitterTest
         assertEquals(a, b);
     }
 
-    private int calcSplits(int subRange)
+    private static int calcSplits(int numTokens, int subRange)
     {
         return Math.max(1, subRange / numTokens);
     }

--- a/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterHelper.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterHelper.java
@@ -27,9 +27,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import org.apache.cassandra.ServerTestUtils;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.QueryProcessor;
@@ -53,7 +50,6 @@ import static org.junit.Assert.assertTrue;
 /**
  * Helper class for for {@link FixedSplitTokenRangeSplitterNoVNodesTest} and {@link FixedSplitTokenRangeSplitterVNodesTest}
  */
-@RunWith(Parameterized.class)
 public class FixedSplitTokenRangeSplitterHelper
 {
     private static final String TABLE1 = "tbl1";

--- a/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterHelper.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterHelper.java
@@ -30,11 +30,20 @@ import java.util.TreeSet;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import org.apache.cassandra.ServerTestUtils;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.dht.BootStrapper;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.service.AutoRepairService;
 import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.tcm.ClusterMetadata;
 
+import static org.apache.cassandra.config.CassandraRelevantProperties.SYSTEM_DISTRIBUTED_DEFAULT_RF;
+import static org.apache.cassandra.cql3.CQLTester.Fuzzed.setupSeed;
+import static org.apache.cassandra.cql3.CQLTester.Fuzzed.updateConfigs;
 import static org.apache.cassandra.repair.autorepair.FixedSplitTokenRangeSplitter.DEFAULT_NUMBER_OF_SUBRANGES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -51,6 +60,23 @@ public class FixedSplitTokenRangeSplitterHelper
     private static final String TABLE2 = "tbl2";
     private static final String TABLE3 = "tbl3";
     public static final String KEYSPACE = "ks";
+
+    public static void setupClass(int numTokens) throws Exception
+    {
+        setupSeed();
+        updateConfigs();
+        DatabaseDescriptor.setPartitioner("org.apache.cassandra.dht.Murmur3Partitioner");
+        ServerTestUtils.prepareServerNoRegister();
+
+        Set<Token> tokens = BootStrapper.getRandomTokens(ClusterMetadata.current(), numTokens);
+        ServerTestUtils.registerLocal(tokens);
+        // Ensure that the on-disk format statics are loaded before the test run
+        Version.LATEST.onDiskFormat();
+        StorageService.instance.doAutoRepairSetup();
+
+        SYSTEM_DISTRIBUTED_DEFAULT_RF.setInt(1);
+        QueryProcessor.executeInternal(String.format("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}", FixedSplitTokenRangeSplitterHelper.KEYSPACE));
+    }
 
     public static void testTokenRangesSplitByTable(int numTokens, int numberOfSubRanges, AutoRepairConfig.RepairType repairType)
     {

--- a/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterNoVNodesTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterNoVNodesTest.java
@@ -22,25 +22,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import org.apache.cassandra.ServerTestUtils;
-import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.QueryProcessor;
-import org.apache.cassandra.dht.BootStrapper;
-import org.apache.cassandra.dht.Token;
-import org.apache.cassandra.index.sai.disk.format.Version;
-import org.apache.cassandra.service.StorageService;
-import org.apache.cassandra.tcm.ClusterMetadata;
-
-import static org.apache.cassandra.config.CassandraRelevantProperties.SYSTEM_DISTRIBUTED_DEFAULT_RF;
-import static org.apache.cassandra.cql3.CQLTester.Fuzzed.setupSeed;
-import static org.apache.cassandra.cql3.CQLTester.Fuzzed.updateConfigs;
 
 /**
  * Unit tests for a setup that does not have v-nodes {@link FixedSplitTokenRangeSplitter}
@@ -73,19 +59,7 @@ public class FixedSplitTokenRangeSplitterNoVNodesTest
     @BeforeClass
     public static void setupClass() throws Exception
     {
-        setupSeed();
-        updateConfigs();
-        DatabaseDescriptor.setPartitioner("org.apache.cassandra.dht.Murmur3Partitioner");
-        ServerTestUtils.prepareServerNoRegister();
-
-        Set<Token> tokens = BootStrapper.getRandomTokens(ClusterMetadata.current(), numTokens);
-        ServerTestUtils.registerLocal(tokens);
-        // Ensure that the on-disk format statics are loaded before the test run
-        Version.LATEST.onDiskFormat();
-        StorageService.instance.doAutoRepairSetup();
-
-        SYSTEM_DISTRIBUTED_DEFAULT_RF.setInt(1);
-        QueryProcessor.executeInternal(String.format("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}", FixedSplitTokenRangeSplitterHelper.KEYSPACE));
+        FixedSplitTokenRangeSplitterHelper.setupClass(numTokens);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterNoVNodesTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterNoVNodesTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.repair.autorepair;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.ServerTestUtils;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.dht.BootStrapper;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.tcm.ClusterMetadata;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.SYSTEM_DISTRIBUTED_DEFAULT_RF;
+import static org.apache.cassandra.cql3.CQLTester.Fuzzed.setupSeed;
+import static org.apache.cassandra.cql3.CQLTester.Fuzzed.updateConfigs;
+
+/**
+ * Unit tests for a setup that does not have v-nodes {@link FixedSplitTokenRangeSplitter}
+ */
+@RunWith(Parameterized.class)
+public class FixedSplitTokenRangeSplitterNoVNodesTest
+{
+    private static final int numTokens = 1;
+
+    @Parameterized.Parameter(0)
+    public AutoRepairConfig.RepairType repairType;
+
+    @Parameterized.Parameter(1)
+    public int numberOfSubRanges;
+
+    @Parameterized.Parameters(name = "repairType={0}, numberOfSubRanges={1}")
+    public static Collection<Object[]> parameters()
+    {
+        List<Object[]> params = new ArrayList<>();
+        for (AutoRepairConfig.RepairType type : AutoRepairConfig.RepairType.values())
+        {
+            for (int subRange : Arrays.asList(1, 2, 4, 8, 16, 32, 64, 128, 256))
+            {
+                params.add(new Object[]{ type, subRange });
+            }
+        }
+        return params;
+    }
+
+    @BeforeClass
+    public static void setupClass() throws Exception
+    {
+        setupSeed();
+        updateConfigs();
+        DatabaseDescriptor.setPartitioner("org.apache.cassandra.dht.Murmur3Partitioner");
+        ServerTestUtils.prepareServerNoRegister();
+
+        Set<Token> tokens = BootStrapper.getRandomTokens(ClusterMetadata.current(), numTokens);
+        ServerTestUtils.registerLocal(tokens);
+        // Ensure that the on-disk format statics are loaded before the test run
+        Version.LATEST.onDiskFormat();
+        StorageService.instance.doAutoRepairSetup();
+
+        SYSTEM_DISTRIBUTED_DEFAULT_RF.setInt(1);
+        QueryProcessor.executeInternal(String.format("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}", FixedSplitTokenRangeSplitterHelper.KEYSPACE));
+    }
+
+    @Test
+    public void testTokenRangesSplitByTable()
+    {
+        FixedSplitTokenRangeSplitterHelper.testTokenRangesSplitByTable(numTokens, numberOfSubRanges, repairType);
+    }
+
+    @Test
+    public void testTokenRangesSplitByKeyspace()
+    {
+        FixedSplitTokenRangeSplitterHelper.testTokenRangesSplitByKeyspace(numTokens, numberOfSubRanges, repairType);
+    }
+
+    @Test
+    public void testTokenRangesWithDefaultSplit()
+    {
+        FixedSplitTokenRangeSplitterHelper.testTokenRangesWithDefaultSplit(numTokens, numberOfSubRanges, repairType);
+    }
+}

--- a/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterNoVNodesTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterNoVNodesTest.java
@@ -77,6 +77,6 @@ public class FixedSplitTokenRangeSplitterNoVNodesTest
     @Test
     public void testTokenRangesWithDefaultSplit()
     {
-        FixedSplitTokenRangeSplitterHelper.testTokenRangesWithDefaultSplit(numTokens, numberOfSubRanges, repairType);
+        FixedSplitTokenRangeSplitterHelper.testTokenRangesWithDefaultSplit(numTokens, repairType);
     }
 }

--- a/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterTest.java
@@ -22,12 +22,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,16 +35,18 @@ import org.junit.runners.Parameterized;
 import org.apache.cassandra.ServerTestUtils;
 import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.cql3.QueryProcessor;
-import org.apache.cassandra.dht.Murmur3Partitioner;
+import org.apache.cassandra.dht.BootStrapper;
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Token;
 import org.apache.cassandra.index.sai.disk.format.Version;
 import org.apache.cassandra.service.AutoRepairService;
 import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.tcm.ClusterMetadata;
 
 import static org.apache.cassandra.config.CassandraRelevantProperties.SYSTEM_DISTRIBUTED_DEFAULT_RF;
 import static org.apache.cassandra.cql3.CQLTester.Fuzzed.setupSeed;
 import static org.apache.cassandra.cql3.CQLTester.Fuzzed.updateConfigs;
+import static org.apache.cassandra.repair.autorepair.FixedSplitTokenRangeSplitter.DEFAULT_SUBRANGES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -61,24 +62,30 @@ public class FixedSplitTokenRangeSplitterTest
     private static final String TABLE1 = "tbl1";
     private static final String TABLE2 = "tbl2";
     private static final String TABLE3 = "tbl3";
-    private static final int totalTokenRanges = 3;
-    private static int numberOfSplits;
 
     @Parameterized.Parameter(0)
     public AutoRepairConfig.RepairType repairType;
 
     @Parameterized.Parameter(1)
-    public int numberOfSubRange;
+    public int numberOfSubRanges;
 
-    @Parameterized.Parameters(name = "repairType={0}, numberOfSubRange={1}")
+    @Parameterized.Parameter(2)
+    public int numTokens;
+
+    public static final int curTokenRange = 1;
+
+    @Parameterized.Parameters(name = "repairType={0}, numberOfSubRanges={1}, numTokens={2}")
     public static Collection<Object[]> parameters()
     {
         List<Object[]> params = new ArrayList<>();
         for (AutoRepairConfig.RepairType type : AutoRepairConfig.RepairType.values())
         {
-            for (int subRange : Arrays.asList(4, 16, 64, 128))
+            for (int subRange : Arrays.asList(1, 2, 4, 8, 16, 32, 64, 128, 256))
             {
-                params.add(new Object[]{ type, subRange });
+                for (int numToken : Arrays.asList(curTokenRange))
+                {
+                    params.add(new Object[]{ type, subRange, numToken });
+                }
             }
         }
         return params;
@@ -92,15 +99,8 @@ public class FixedSplitTokenRangeSplitterTest
         DatabaseDescriptor.setPartitioner("org.apache.cassandra.dht.Murmur3Partitioner");
         ServerTestUtils.prepareServerNoRegister();
 
-        Token t1 = new Murmur3Partitioner.LongToken(-9223372036854775808L);
-        Token t2 = new Murmur3Partitioner.LongToken(-3074457345618258603L);
-        Token t3 = new Murmur3Partitioner.LongToken(3074457345618258602L);
-        Set<Token> tokens = new HashSet<>();
-        tokens.add(t1);
-        tokens.add(t2);
-        tokens.add(t3);
-
-        ServerTestUtils.registerLocal(tokens);
+        Set<Token> tokens1 = BootStrapper.getRandomTokens(ClusterMetadata.current(), curTokenRange);
+        ServerTestUtils.registerLocal(tokens1);
         // Ensure that the on-disk format statics are loaded before the test run
         Version.LATEST.onDiskFormat();
         StorageService.instance.doAutoRepairSetup();
@@ -109,18 +109,13 @@ public class FixedSplitTokenRangeSplitterTest
         QueryProcessor.executeInternal(String.format("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}", KEYSPACE));
     }
 
-    @Before
-    public void before()
-    {
-        numberOfSplits = numberOfSubRange / totalTokenRanges;
-    }
-
     @Test
     public void testTokenRangesSplitByTable()
     {
+        int numberOfSplits = calcSplits(numberOfSubRanges);
         AutoRepairService.instance.getAutoRepairConfig().setRepairByKeyspace(repairType, false);
         Collection<Range<Token>> tokens = StorageService.instance.getPrimaryRanges(KEYSPACE);
-        assertEquals(totalTokenRanges, tokens.size());
+        assertEquals(numTokens, tokens.size());
         List<String> tables = Arrays.asList(TABLE1, TABLE2, TABLE3);
         List<Range<Token>> expectedToken = new ArrayList<>();
         for (int i = 0; i < tables.size(); i++)
@@ -133,7 +128,7 @@ public class FixedSplitTokenRangeSplitterTest
 
         List<PrioritizedRepairPlan> plan = PrioritizedRepairPlan.buildSingleKeyspacePlan(repairType, KEYSPACE, TABLE1, TABLE2, TABLE3);
 
-        Iterator<KeyspaceRepairAssignments> keyspaceAssignments = new FixedSplitTokenRangeSplitter(repairType, Collections.singletonMap(FixedSplitTokenRangeSplitter.NUMBER_OF_SUBRANGES, Integer.toString(numberOfSubRange)))
+        Iterator<KeyspaceRepairAssignments> keyspaceAssignments = new FixedSplitTokenRangeSplitter(repairType, Collections.singletonMap(FixedSplitTokenRangeSplitter.NUMBER_OF_SUBRANGES, Integer.toString(numberOfSubRanges)))
                                                                   .getRepairAssignments(true, plan);
 
         // should be only 1 entry for the keyspace.
@@ -142,37 +137,31 @@ public class FixedSplitTokenRangeSplitterTest
         assertFalse(keyspaceAssignments.hasNext());
 
         List<RepairAssignment> assignments = keyspace.getRepairAssignments();
-        assertEquals(totalTokenRanges * numberOfSplits * tables.size(), assignments.size());
+        assertEquals(numTokens * numberOfSplits * tables.size(), assignments.size());
         assertEquals(expectedToken.size(), assignments.size());
 
-        int expectedTableIndex = -1;
-        for (int i = 0; i < totalTokenRanges * numberOfSplits * tables.size(); i++)
+        int assignmentsPerTable = numTokens * numberOfSplits;
+        for (int i = 0; i < tables.size(); i++)
         {
-            if (i % (totalTokenRanges * numberOfSplits) == 0)
+            List<RepairAssignment> assignmentForATable = new ArrayList<>();
+            List<Range<Token>> expectedTokensForATable = new ArrayList<>();
+            for (int j = 0; j < assignmentsPerTable; j++)
             {
-                expectedTableIndex++;
+                assertEquals(Arrays.asList(tables.get(i)), assignments.get(i*assignmentsPerTable + j).getTableNames());
+                assignmentForATable.add(assignments.get(i*assignmentsPerTable+j));
+                expectedTokensForATable.add(expectedToken.get(i*assignmentsPerTable+j));
             }
-        }
-
-        expectedTableIndex = -1;
-        // should be a set of ranges for each table.
-        for (int i = 0; i < totalTokenRanges * numberOfSplits * tables.size(); i++)
-        {
-            if (i % (totalTokenRanges * numberOfSplits) == 0)
-            {
-                expectedTableIndex++;
-            }
-            assertEquals(expectedToken.get(i), assignments.get(i).getTokenRange());
-            assertEquals(Arrays.asList(tables.get(expectedTableIndex)), assignments.get(i).getTableNames());
+            compare(numberOfSplits, expectedTokensForATable, assignmentForATable);
         }
     }
 
     @Test
     public void testTokenRangesSplitByKeyspace()
     {
+        int numberOfSplits = calcSplits(numberOfSubRanges);
         AutoRepairService.instance.getAutoRepairConfig().setRepairByKeyspace(repairType, true);
         Collection<Range<Token>> tokens = StorageService.instance.getPrimaryRanges(KEYSPACE);
-        assertEquals(totalTokenRanges, tokens.size());
+        assertEquals(numTokens, tokens.size());
         List<String> tables = Arrays.asList(TABLE1, TABLE2, TABLE3);
         List<Range<Token>> expectedToken = new ArrayList<>();
         for (Range<Token> range : tokens)
@@ -182,7 +171,7 @@ public class FixedSplitTokenRangeSplitterTest
 
         List<PrioritizedRepairPlan> plan = PrioritizedRepairPlan.buildSingleKeyspacePlan(repairType, KEYSPACE, TABLE1, TABLE2, TABLE3);
 
-        Iterator<KeyspaceRepairAssignments> keyspaceAssignments = new FixedSplitTokenRangeSplitter(repairType, Collections.singletonMap(FixedSplitTokenRangeSplitter.NUMBER_OF_SUBRANGES, Integer.toString(numberOfSubRange)))
+        Iterator<KeyspaceRepairAssignments> keyspaceAssignments = new FixedSplitTokenRangeSplitter(repairType, Collections.singletonMap(FixedSplitTokenRangeSplitter.NUMBER_OF_SUBRANGES, Integer.toString(numberOfSubRanges)))
                                                                   .getRepairAssignments(true, plan);
 
         // should be only 1 entry for the keyspace.
@@ -193,23 +182,23 @@ public class FixedSplitTokenRangeSplitterTest
         List<RepairAssignment> assignments = keyspace.getRepairAssignments();
         assertNotNull(assignments);
 
-        assertEquals(totalTokenRanges * numberOfSplits, assignments.size());
+        assertEquals(numTokens * numberOfSplits, assignments.size());
         assertEquals(expectedToken.size(), assignments.size());
 
-        // should only be one set of ranges for the entire keyspace.
-        for (int i = 0; i < totalTokenRanges * numberOfSplits; i++)
-        {
-            assertEquals(expectedToken.get(i), assignments.get(i).getTokenRange());
-            assertEquals(tables, assignments.get(i).getTableNames());
-        }
+        compare(numberOfSplits, expectedToken, assignments);
     }
 
     @Test
-    public void testTokenRangesNoSplitByDefault()
+    public void testTokenRangesWithDefaultSplit()
     {
+        int numberOfSplits = calcSplits(DEFAULT_SUBRANGES);
         Collection<Range<Token>> tokens = StorageService.instance.getPrimaryRanges(KEYSPACE);
-        assertEquals(totalTokenRanges, tokens.size());
-        List<Range<Token>> expectedToken = new ArrayList<>(tokens);
+        assertEquals(numTokens, tokens.size());
+        List<Range<Token>> expectedToken = new ArrayList<>();
+        for (Range<Token> range : tokens)
+        {
+            expectedToken.addAll(AutoRepairUtils.split(range, numberOfSplits));
+        }
 
         List<PrioritizedRepairPlan> plan = PrioritizedRepairPlan.buildSingleKeyspacePlan(repairType, KEYSPACE, TABLE1);
 
@@ -224,10 +213,26 @@ public class FixedSplitTokenRangeSplitterTest
         assertNotNull(assignments);
 
         // should be 3 entries for the table which covers each token range.
-        assertEquals(totalTokenRanges, assignments.size());
-        for (int i = 0; i < totalTokenRanges; i++)
+        assertEquals(numTokens * numberOfSplits, assignments.size());
+
+        compare(numberOfSplits, expectedToken, assignments);
+    }
+
+    private void compare(int numberOfSplits, List<Range<Token>> expectedToken, List<RepairAssignment> assignments)
+    {
+        assertEquals(expectedToken.size(), assignments.size());
+        Set<Range<Token>> a = new TreeSet<>();
+        Set<Range<Token>> b = new TreeSet<>();
+        for (int i = 0; i < numTokens * numberOfSplits; i++)
         {
-            assertEquals(expectedToken.get(i), assignments.get(i).getTokenRange());
+            a.add(expectedToken.get(i));
+            b.add(assignments.get(i).getTokenRange());
         }
+        assertEquals(a, b);
+    }
+
+    private int calcSplits(int subRange)
+    {
+        return Math.max(1, subRange / numTokens);
     }
 }

--- a/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterTest.java
@@ -26,8 +26,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.Map;
 
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,19 +61,27 @@ public class FixedSplitTokenRangeSplitterTest
     private static final String TABLE1 = "tbl1";
     private static final String TABLE2 = "tbl2";
     private static final String TABLE3 = "tbl3";
-    private static final int numberOfSubRanges = 4;
-
     private static final int totalTokenRanges = 3;
     private static int numberOfSplits;
-    private static final Map<String, String> splitterParams = Collections.singletonMap(FixedSplitTokenRangeSplitter.NUMBER_OF_SUBRANGES, Integer.toString(numberOfSubRanges));
 
-    @Parameterized.Parameter()
+    @Parameterized.Parameter(0)
     public AutoRepairConfig.RepairType repairType;
 
-    @Parameterized.Parameters(name = "repairType={0}")
-    public static Collection<AutoRepairConfig.RepairType> repairTypes()
+    @Parameterized.Parameter(1)
+    public int numberOfSubRange;
+
+    @Parameterized.Parameters(name = "repairType={0}, numberOfSubRange={1}")
+    public static Collection<Object[]> parameters()
     {
-        return Arrays.asList(AutoRepairConfig.RepairType.values());
+        List<Object[]> params = new ArrayList<>();
+        for (AutoRepairConfig.RepairType type : AutoRepairConfig.RepairType.values())
+        {
+            for (int subRange : Arrays.asList(4, 16, 64, 128))
+            {
+                params.add(new Object[]{ type, subRange });
+            }
+        }
+        return params;
     }
 
     @BeforeClass
@@ -99,8 +107,12 @@ public class FixedSplitTokenRangeSplitterTest
 
         SYSTEM_DISTRIBUTED_DEFAULT_RF.setInt(1);
         QueryProcessor.executeInternal(String.format("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}", KEYSPACE));
+    }
 
-        numberOfSplits = numberOfSubRanges/totalTokenRanges;
+    @Before
+    public void before()
+    {
+        numberOfSplits = numberOfSubRange / totalTokenRanges;
     }
 
     @Test
@@ -121,7 +133,7 @@ public class FixedSplitTokenRangeSplitterTest
 
         List<PrioritizedRepairPlan> plan = PrioritizedRepairPlan.buildSingleKeyspacePlan(repairType, KEYSPACE, TABLE1, TABLE2, TABLE3);
 
-        Iterator<KeyspaceRepairAssignments> keyspaceAssignments = new FixedSplitTokenRangeSplitter(repairType, splitterParams)
+        Iterator<KeyspaceRepairAssignments> keyspaceAssignments = new FixedSplitTokenRangeSplitter(repairType, Collections.singletonMap(FixedSplitTokenRangeSplitter.NUMBER_OF_SUBRANGES, Integer.toString(numberOfSubRange)))
                                                                   .getRepairAssignments(true, plan);
 
         // should be only 1 entry for the keyspace.
@@ -130,7 +142,7 @@ public class FixedSplitTokenRangeSplitterTest
         assertFalse(keyspaceAssignments.hasNext());
 
         List<RepairAssignment> assignments = keyspace.getRepairAssignments();
-        assertEquals(totalTokenRanges*numberOfSplits*tables.size(), assignments.size());
+        assertEquals(totalTokenRanges * numberOfSplits * tables.size(), assignments.size());
         assertEquals(expectedToken.size(), assignments.size());
 
         int expectedTableIndex = -1;
@@ -144,9 +156,9 @@ public class FixedSplitTokenRangeSplitterTest
 
         expectedTableIndex = -1;
         // should be a set of ranges for each table.
-        for (int i = 0; i<totalTokenRanges*numberOfSplits*tables.size(); i++)
+        for (int i = 0; i < totalTokenRanges * numberOfSplits * tables.size(); i++)
         {
-            if (i % (totalTokenRanges*numberOfSplits) == 0)
+            if (i % (totalTokenRanges * numberOfSplits) == 0)
             {
                 expectedTableIndex++;
             }
@@ -170,7 +182,7 @@ public class FixedSplitTokenRangeSplitterTest
 
         List<PrioritizedRepairPlan> plan = PrioritizedRepairPlan.buildSingleKeyspacePlan(repairType, KEYSPACE, TABLE1, TABLE2, TABLE3);
 
-        Iterator<KeyspaceRepairAssignments> keyspaceAssignments = new FixedSplitTokenRangeSplitter(repairType, splitterParams)
+        Iterator<KeyspaceRepairAssignments> keyspaceAssignments = new FixedSplitTokenRangeSplitter(repairType, Collections.singletonMap(FixedSplitTokenRangeSplitter.NUMBER_OF_SUBRANGES, Integer.toString(numberOfSubRange)))
                                                                   .getRepairAssignments(true, plan);
 
         // should be only 1 entry for the keyspace.
@@ -181,11 +193,11 @@ public class FixedSplitTokenRangeSplitterTest
         List<RepairAssignment> assignments = keyspace.getRepairAssignments();
         assertNotNull(assignments);
 
-        assertEquals(totalTokenRanges*numberOfSplits, assignments.size());
+        assertEquals(totalTokenRanges * numberOfSplits, assignments.size());
         assertEquals(expectedToken.size(), assignments.size());
 
         // should only be one set of ranges for the entire keyspace.
-        for (int i = 0; i<totalTokenRanges*numberOfSplits; i++)
+        for (int i = 0; i < totalTokenRanges * numberOfSplits; i++)
         {
             assertEquals(expectedToken.get(i), assignments.get(i).getTokenRange());
             assertEquals(tables, assignments.get(i).getTableNames());

--- a/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterTest.java
@@ -61,8 +61,11 @@ public class FixedSplitTokenRangeSplitterTest
     private static final String TABLE1 = "tbl1";
     private static final String TABLE2 = "tbl2";
     private static final String TABLE3 = "tbl3";
+    private static final int numberOfSubRanges = 4;
 
-    private static final Map<String, String> splitterParams = Collections.singletonMap(FixedSplitTokenRangeSplitter.NUMBER_OF_SUBRANGES, Integer.toString(4));
+    private static final int totalTokenRanges = 3;
+    private static int numberOfSplits;
+    private static final Map<String, String> splitterParams = Collections.singletonMap(FixedSplitTokenRangeSplitter.NUMBER_OF_SUBRANGES, Integer.toString(numberOfSubRanges));
 
     @Parameterized.Parameter()
     public AutoRepairConfig.RepairType repairType;
@@ -96,16 +99,16 @@ public class FixedSplitTokenRangeSplitterTest
 
         SYSTEM_DISTRIBUTED_DEFAULT_RF.setInt(1);
         QueryProcessor.executeInternal(String.format("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}", KEYSPACE));
+
+        numberOfSplits = numberOfSubRanges/totalTokenRanges;
     }
 
     @Test
     public void testTokenRangesSplitByTable()
     {
         AutoRepairService.instance.getAutoRepairConfig().setRepairByKeyspace(repairType, false);
-        int totalTokenRanges = 3;
         Collection<Range<Token>> tokens = StorageService.instance.getPrimaryRanges(KEYSPACE);
         assertEquals(totalTokenRanges, tokens.size());
-        int numberOfSplits = 4;
         List<String> tables = Arrays.asList(TABLE1, TABLE2, TABLE3);
         List<Range<Token>> expectedToken = new ArrayList<>();
         for (int i = 0; i < tables.size(); i++)
@@ -156,10 +159,8 @@ public class FixedSplitTokenRangeSplitterTest
     public void testTokenRangesSplitByKeyspace()
     {
         AutoRepairService.instance.getAutoRepairConfig().setRepairByKeyspace(repairType, true);
-        int totalTokenRanges = 3;
         Collection<Range<Token>> tokens = StorageService.instance.getPrimaryRanges(KEYSPACE);
         assertEquals(totalTokenRanges, tokens.size());
-        int numberOfSplits = 4;
         List<String> tables = Arrays.asList(TABLE1, TABLE2, TABLE3);
         List<Range<Token>> expectedToken = new ArrayList<>();
         for (Range<Token> range : tokens)
@@ -195,7 +196,6 @@ public class FixedSplitTokenRangeSplitterTest
     public void testTokenRangesNoSplitByDefault()
     {
         Collection<Range<Token>> tokens = StorageService.instance.getPrimaryRanges(KEYSPACE);
-        int totalTokenRanges = 3;
         assertEquals(totalTokenRanges, tokens.size());
         List<Range<Token>> expectedToken = new ArrayList<>(tokens);
 

--- a/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterVNodesTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterVNodesTest.java
@@ -77,6 +77,6 @@ public class FixedSplitTokenRangeSplitterVNodesTest
     @Test
     public void testTokenRangesWithDefaultSplit()
     {
-        FixedSplitTokenRangeSplitterHelper.testTokenRangesWithDefaultSplit(numTokens, numberOfSubRanges, repairType);
+        FixedSplitTokenRangeSplitterHelper.testTokenRangesWithDefaultSplit(numTokens, repairType);
     }
 }

--- a/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterVNodesTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterVNodesTest.java
@@ -22,25 +22,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import org.apache.cassandra.ServerTestUtils;
-import org.apache.cassandra.config.DatabaseDescriptor;
-import org.apache.cassandra.cql3.QueryProcessor;
-import org.apache.cassandra.dht.BootStrapper;
-import org.apache.cassandra.dht.Token;
-import org.apache.cassandra.index.sai.disk.format.Version;
-import org.apache.cassandra.service.StorageService;
-import org.apache.cassandra.tcm.ClusterMetadata;
-
-import static org.apache.cassandra.config.CassandraRelevantProperties.SYSTEM_DISTRIBUTED_DEFAULT_RF;
-import static org.apache.cassandra.cql3.CQLTester.Fuzzed.setupSeed;
-import static org.apache.cassandra.cql3.CQLTester.Fuzzed.updateConfigs;
 
 /**
  * Unit tests for a setup that has v-nodes {@link FixedSplitTokenRangeSplitter}
@@ -73,19 +59,7 @@ public class FixedSplitTokenRangeSplitterVNodesTest
     @BeforeClass
     public static void setupClass() throws Exception
     {
-        setupSeed();
-        updateConfigs();
-        DatabaseDescriptor.setPartitioner("org.apache.cassandra.dht.Murmur3Partitioner");
-        ServerTestUtils.prepareServerNoRegister();
-
-        Set<Token> tokens = BootStrapper.getRandomTokens(ClusterMetadata.current(), numTokens);
-        ServerTestUtils.registerLocal(tokens);
-        // Ensure that the on-disk format statics are loaded before the test run
-        Version.LATEST.onDiskFormat();
-        StorageService.instance.doAutoRepairSetup();
-
-        SYSTEM_DISTRIBUTED_DEFAULT_RF.setInt(1);
-        QueryProcessor.executeInternal(String.format("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}", FixedSplitTokenRangeSplitterHelper.KEYSPACE));
+        FixedSplitTokenRangeSplitterHelper.setupClass(numTokens);
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterVNodesTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/FixedSplitTokenRangeSplitterVNodesTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.repair.autorepair;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.cassandra.ServerTestUtils;
+import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.dht.BootStrapper;
+import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.index.sai.disk.format.Version;
+import org.apache.cassandra.service.StorageService;
+import org.apache.cassandra.tcm.ClusterMetadata;
+
+import static org.apache.cassandra.config.CassandraRelevantProperties.SYSTEM_DISTRIBUTED_DEFAULT_RF;
+import static org.apache.cassandra.cql3.CQLTester.Fuzzed.setupSeed;
+import static org.apache.cassandra.cql3.CQLTester.Fuzzed.updateConfigs;
+
+/**
+ * Unit tests for a setup that has v-nodes {@link FixedSplitTokenRangeSplitter}
+ */
+@RunWith(Parameterized.class)
+public class FixedSplitTokenRangeSplitterVNodesTest
+{
+    private static final int numTokens = 16;
+
+    @Parameterized.Parameter(0)
+    public AutoRepairConfig.RepairType repairType;
+
+    @Parameterized.Parameter(1)
+    public int numberOfSubRanges;
+
+    @Parameterized.Parameters(name = "repairType={0}, numberOfSubRanges={1}")
+    public static Collection<Object[]> parameters()
+    {
+        List<Object[]> params = new ArrayList<>();
+        for (AutoRepairConfig.RepairType type : AutoRepairConfig.RepairType.values())
+        {
+            for (int subRange : Arrays.asList(1, 2, 4, 8, 16, 32, 64, 128, 256))
+            {
+                params.add(new Object[]{ type, subRange });
+            }
+        }
+        return params;
+    }
+
+    @BeforeClass
+    public static void setupClass() throws Exception
+    {
+        setupSeed();
+        updateConfigs();
+        DatabaseDescriptor.setPartitioner("org.apache.cassandra.dht.Murmur3Partitioner");
+        ServerTestUtils.prepareServerNoRegister();
+
+        Set<Token> tokens = BootStrapper.getRandomTokens(ClusterMetadata.current(), numTokens);
+        ServerTestUtils.registerLocal(tokens);
+        // Ensure that the on-disk format statics are loaded before the test run
+        Version.LATEST.onDiskFormat();
+        StorageService.instance.doAutoRepairSetup();
+
+        SYSTEM_DISTRIBUTED_DEFAULT_RF.setInt(1);
+        QueryProcessor.executeInternal(String.format("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}", FixedSplitTokenRangeSplitterHelper.KEYSPACE));
+    }
+
+    @Test
+    public void testTokenRangesSplitByTable()
+    {
+        FixedSplitTokenRangeSplitterHelper.testTokenRangesSplitByTable(numTokens, numberOfSubRanges, repairType);
+    }
+
+    @Test
+    public void testTokenRangesSplitByKeyspace()
+    {
+        FixedSplitTokenRangeSplitterHelper.testTokenRangesSplitByKeyspace(numTokens, numberOfSubRanges, repairType);
+    }
+
+    @Test
+    public void testTokenRangesWithDefaultSplit()
+    {
+        FixedSplitTokenRangeSplitterHelper.testTokenRangesWithDefaultSplit(numTokens, numberOfSubRanges, repairType);
+    }
+}


### PR DESCRIPTION
*Change#1* If we select FixedSplitTokenRangeSplitter with v-nodes value 256 and number_of_subranges: 2, it would split each v-node in 2, which means 512 repair splits.
We should optimize this to avoid micro splitting by default, so there will be 256 repair splits.
If one needs more splits, then they can set a higher number for number_of_subranges to 4 and then can still get 512 splits.
*Change#1* Currently, there is no *nodetool* way to set *repair_by_keyspace*, the PR also takes care of it

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-20419)

