### PR TITLE
Move auto-repair retry policy config to repair-type level

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.1
+ * Move auto-repair retry policy config to repair-type level (CASSANDRA-20430)
  * Unregistering a node should also remove it from tokenMap if it is there and recalculate the placements (CASSANDRA-20346)
  * Fix PartitionUpdate.isEmpty deserialization issue to avoid potential EOFException (CASSANDRA-20345)
  * Avoid adding LEFT nodes to tokenMap on upgrade from gossip (CASSANDRA-20344)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,4 @@
 5.1
- * Move auto-repair retry policy config to repair-type level (CASSANDRA-20430)
  * Unregistering a node should also remove it from tokenMap if it is there and recalculate the placements (CASSANDRA-20346)
  * Fix PartitionUpdate.isEmpty deserialization issue to avoid potential EOFException (CASSANDRA-20345)
  * Avoid adding LEFT nodes to tokenMap on upgrade from gossip (CASSANDRA-20344)

--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2715,10 +2715,6 @@ storage_compatibility_mode: NONE
 #   # Time interval between successive checks to see if ongoing repairs are complete or if it is time to schedule
 #   # repairs.
 #   repair_check_interval: 5m
-#   # Maximum number of retries for a repair session.
-#   repair_max_retries: 3
-#   # Backoff time before retrying a repair session.
-#   repair_retry_backoff: 30s
 #   # Minimum duration for the execution of a single repair task. This prevents the scheduler from overwhelming
 #   # the node by scheduling too many repair tasks in a short period of time.
 #   repair_task_min_duration: 5s
@@ -2760,6 +2756,10 @@ storage_compatibility_mode: NONE
 #     # Repair only the primary ranges owned by a node. Equivalent to the -pr option in nodetool repair. Defaults
 #     # to true. General advice is to keep this true.
 #     repair_primary_token_range_only: true
+#     # Maximum number of retries for a repair session.
+#     repair_max_retries: 3
+#     # Backoff time before retrying a repair session.
+#     repair_retry_backoff: 30s
 #     token_range_splitter:
 #       # Splitter implementation to generate repair assignments. Defaults to RepairTokenRangeSplitter.
 #       class_name: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -2432,10 +2432,6 @@ storage_compatibility_mode: NONE
 #   # Time interval between successive checks to see if ongoing repairs are complete or if it is time to schedule
 #   # repairs.
 #   repair_check_interval: 5m
-#   # Maximum number of retries for a repair session.
-#   repair_max_retries: 3
-#   # Backoff time before retrying a repair session.
-#   repair_retry_backoff: 30s
 #   # Minimum duration for the execution of a single repair task. This prevents the scheduler from overwhelming
 #   # the node by scheduling too many repair tasks in a short period of time.
 #   repair_task_min_duration: 5s
@@ -2477,6 +2473,10 @@ storage_compatibility_mode: NONE
 #     # Repair only the primary ranges owned by a node. Equivalent to the -pr option in nodetool repair. Defaults
 #     # to true. General advice is to keep this true.
 #     repair_primary_token_range_only: true
+#     # Maximum number of retries for a repair session.
+#     repair_max_retries: 3
+#     # Backoff time before retrying a repair session.
+#     repair_retry_backoff: 30s
 #     token_range_splitter:
 #       # Splitter implementation to generate repair assignments. Defaults to RepairTokenRangeSplitter.
 #       class_name: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter

--- a/doc/modules/cassandra/pages/managing/operating/auto_repair.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/auto_repair.adoc
@@ -164,9 +164,6 @@ for each repair type (full, incremental, and preview_repaired), and based on tha
 | repair_check_interval | 5m | Time interval between successive checks to see if ongoing repairs are complete or if it
 is time to schedule repairs.
 | repair_max_retries | 3 | Maximum number of retries for a repair session.
-| repair_retry_backoff | 30s | Backoff time before retrying a repair session.
-| repair_task_min_duration | 5s | Minimum duration for the execution of a single repair task. This prevents the
-scheduler from overwhelming the node by scheduling too many repair tasks in a short period of time.
 | history_clear_delete_hosts_buffer_interval | 2h | The scheduler needs to adjust its order when nodes leave the ring.
 Deleted hosts are tracked in metadata for a specified duration to ensure they are indeed removed before adjustments
 are made to the schedule.
@@ -212,6 +209,9 @@ centers. Useful if you have keyspaces that are not replicated in certain data ce
 schedule in certain data centers.
 | repair_primary_token_range_only | true | Repair only the primary ranges owned by a node. Equivalent to the -pr option
 in nodetool repair. General advice is to keep this true.
+| repair_retry_backoff | 30s | Backoff time before retrying a repair session.
+| repair_task_min_duration | 5s | Minimum duration for the execution of a single repair task. This prevents the
+scheduler from overwhelming the node by scheduling too many repair tasks in a short period of time.
 |===
 
 === `RepairTokenRangeSplitter` configuration
@@ -352,8 +352,6 @@ $> nodetool getautorepairconfig
 repair scheduler configuration:
 	repair_check_interval: 5m
 	repair_max_retries: 3
-	repair_retry_backoff: 30s
-	repair_task_min_duration: 5s
 	history_clear_delete_hosts_buffer_interval: 2h
 configuration for repair_type: full
 	enabled: true
@@ -370,6 +368,8 @@ configuration for repair_type: full
 	initial_scheduler_delay: 5m
 	repair_session_timeout: 3h
 	force_repair_new_node: false
+	repair_retry_backoff: 30s
+	repair_task_min_duration: 5s
 	token_range_splitter: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
 	token_range_splitter.bytes_per_assignment: 50GiB
 	token_range_splitter.partitions_per_assignment: 1048576
@@ -390,6 +390,8 @@ configuration for repair_type: incremental
 	initial_scheduler_delay: 5m
 	repair_session_timeout: 3h
 	force_repair_new_node: false
+	repair_retry_backoff: 30s
+	repair_task_min_duration: 5s
 	token_range_splitter: org.apache.cassandra.repair.autorepair.RepairTokenRangeSplitter
 	token_range_splitter.bytes_per_assignment: 50GiB
 	token_range_splitter.partitions_per_assignment: 1048576

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -313,7 +313,7 @@ public class AutoRepair
                     boolean success = false;
                     int retryCount = 0;
                     Future<?> f = null;
-                    while (retryCount <= config.getRepairMaxRetries())
+                    while (retryCount <= config.getRepairMaxRetries(repairType))
                     {
                         RepairCoordinator task = repairState.getRepairRunnable(keyspaceName,
                                                                             Lists.newArrayList(curRepairAssignment.getTableNames()),
@@ -336,14 +336,14 @@ public class AutoRepair
                         {
                             break;
                         }
-                        else if (retryCount < config.getRepairMaxRetries())
+                        else if (retryCount < config.getRepairMaxRetries(repairType))
                         {
                             boolean cancellationStatus = f.cancel(true);
                             logger.warn("Repair failed for range {}-{} for {} tables {} with cancellationStatus: {} retrying after {} seconds...",
                                         tokenRange.left, tokenRange.right,
                                         keyspaceName, curRepairAssignment.getTableNames(),
-                                        cancellationStatus, config.getRepairRetryBackoff().toSeconds());
-                            sleepFunc.accept(config.getRepairRetryBackoff().toSeconds(), TimeUnit.SECONDS);
+                                        cancellationStatus, config.getRepairRetryBackoff(repairType).toSeconds());
+                            sleepFunc.accept(config.getRepairRetryBackoff(repairType).toSeconds(), TimeUnit.SECONDS);
                         }
                         retryCount++;
                     }

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
@@ -56,10 +56,6 @@ public class AutoRepairConfig implements Serializable
     // The scheduler needs to adjust its order when nodes leave the ring. Deleted hosts are tracked in metadata
     // for a specified duration to ensure they are indeed removed before adjustments are made to the schedule.
     public volatile DurationSpec.IntSecondsBound history_clear_delete_hosts_buffer_interval = new DurationSpec.IntSecondsBound("2h");
-    // Maximum number of retries for a repair session.
-    public volatile Integer repair_max_retries = 3;
-    // Backoff time before retrying a repair session.
-    public volatile DurationSpec.LongSecondsBound repair_retry_backoff = new DurationSpec.LongSecondsBound("30s");
     // Minimum duration for the execution of a single repair task. This prevents the scheduler from overwhelming
     // the node by scheduling too many repair tasks in a short period of time.
     public volatile DurationSpec.LongSecondsBound repair_task_min_duration = new DurationSpec.LongSecondsBound("5s");
@@ -167,26 +163,6 @@ public class AutoRepairConfig implements Serializable
     public void setAutoRepairHistoryClearDeleteHostsBufferInterval(String duration)
     {
         history_clear_delete_hosts_buffer_interval = new DurationSpec.IntSecondsBound(duration);
-    }
-
-    public int getRepairMaxRetries()
-    {
-        return repair_max_retries;
-    }
-
-    public void setRepairMaxRetries(int maxRetries)
-    {
-        repair_max_retries = maxRetries;
-    }
-
-    public DurationSpec.LongSecondsBound getRepairRetryBackoff()
-    {
-        return repair_retry_backoff;
-    }
-
-    public void setRepairRetryBackoff(String interval)
-    {
-        repair_retry_backoff = new DurationSpec.LongSecondsBound(interval);
     }
 
     public DurationSpec.LongSecondsBound getRepairTaskMinDuration()
@@ -360,6 +336,26 @@ public class AutoRepairConfig implements Serializable
         getOptions(repairType).repair_session_timeout = new DurationSpec.IntSecondsBound(repairSessionTimeout);
     }
 
+    public int getRepairMaxRetries(RepairType repairType)
+    {
+        return applyOverrides(repairType, opt -> opt.repair_max_retries);
+    }
+
+    public void setRepairMaxRetries(RepairType repairType, int maxRetries)
+    {
+        getOptions(repairType).repair_max_retries = maxRetries;
+    }
+
+    public DurationSpec.LongSecondsBound getRepairRetryBackoff(RepairType repairType)
+    {
+        return applyOverrides(repairType, opt -> opt.repair_retry_backoff);
+    }
+
+    public void setRepairRetryBackoff(RepairType repairType, String interval)
+    {
+        getOptions(repairType).repair_retry_backoff = new DurationSpec.LongSecondsBound(interval);
+    }
+
     @VisibleForTesting
     static IAutoRepairTokenRangeSplitter newAutoRepairTokenRangeSplitter(RepairType repairType, ParameterizedClass parameterizedClass) throws ConfigurationException
     {
@@ -505,6 +501,10 @@ public class AutoRepairConfig implements Serializable
         public volatile DurationSpec.IntSecondsBound initial_scheduler_delay;
         // Timeout for resuming stuck repair sessions.
         public volatile DurationSpec.IntSecondsBound repair_session_timeout;
+        // Maximum number of retries for a repair session.
+        public volatile Integer repair_max_retries = 3;
+        // Backoff time before retrying a repair session.
+        public volatile DurationSpec.LongSecondsBound repair_retry_backoff = new DurationSpec.LongSecondsBound("30s");
 
         public String toString()
         {

--- a/src/java/org/apache/cassandra/service/AutoRepairService.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairService.java
@@ -100,8 +100,6 @@ public class AutoRepairService implements AutoRepairServiceMBean
         StringBuilder sb = new StringBuilder();
         sb.append("repair scheduler configuration:");
         appendConfig(sb, "repair_check_interval", config.getRepairCheckInterval());
-        appendConfig(sb, "repair_max_retries", config.getRepairMaxRetries());
-        appendConfig(sb, "repair_retry_backoff", config.getRepairRetryBackoff());
         appendConfig(sb, "repair_task_min_duration", config.getRepairTaskMinDuration());
         appendConfig(sb, "history_clear_delete_hosts_buffer_interval", config.getAutoRepairHistoryClearDeleteHostsBufferInterval());
         for (RepairType repairType : RepairType.values())
@@ -160,18 +158,6 @@ public class AutoRepairService implements AutoRepairServiceMBean
     public void setAutoRepairHistoryClearDeleteHostsBufferDuration(String duration)
     {
         config.setAutoRepairHistoryClearDeleteHostsBufferInterval(duration);
-    }
-
-    @Override
-    public void setAutoRepairMaxRetriesCount(int retries)
-    {
-        config.setRepairMaxRetries(retries);
-    }
-
-    @Override
-    public void setAutoRepairRetryBackoff(String interval)
-    {
-        config.setRepairRetryBackoff(interval);
     }
 
     @Override
@@ -261,6 +247,18 @@ public class AutoRepairService implements AutoRepairServiceMBean
         config.setRepairByKeyspace(RepairType.parse(repairType), repairByKeyspace);
     }
 
+    @Override
+    public void setAutoRepairMaxRetriesCount(String repairType, int retries)
+    {
+        config.setRepairMaxRetries(RepairType.parse(repairType), retries);
+    }
+
+    @Override
+    public void setAutoRepairRetryBackoff(String repairType, String interval)
+    {
+        config.setRepairRetryBackoff(RepairType.parse(repairType), interval);
+    }
+
     private String formatRepairTypeConfig(RepairType repairType, AutoRepairConfig config)
     {
         StringBuilder sb = new StringBuilder();
@@ -288,6 +286,8 @@ public class AutoRepairService implements AutoRepairServiceMBean
             appendConfig(sb , "initial_scheduler_delay", config.getInitialSchedulerDelay(repairType));
             appendConfig(sb , "repair_session_timeout", config.getRepairSessionTimeout(repairType));
             appendConfig(sb , "force_repair_new_node", config.getForceRepairNewNode(repairType));
+            appendConfig(sb , "repair_max_retries", config.getRepairMaxRetries(repairType));
+            appendConfig(sb , "repair_retry_backoff", config.getRepairRetryBackoff(repairType));
 
             final ParameterizedClass splitterClass = config.getTokenRangeSplitter(repairType);
             final String splitterClassName =  splitterClass.class_name != null ? splitterClass.class_name : AutoRepairConfig.DEFAULT_SPLITTER.getName();

--- a/src/java/org/apache/cassandra/service/AutoRepairServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairServiceMBean.java
@@ -39,10 +39,6 @@ public interface AutoRepairServiceMBean
 
     public void setAutoRepairHistoryClearDeleteHostsBufferDuration(String duration);
 
-    public void setAutoRepairMaxRetriesCount(int retries);
-
-    public void setAutoRepairRetryBackoff(String interval);
-
     public void setAutoRepairMinRepairTaskDuration(String duration);
 
     public void setRepairSSTableCountHigherThreshold(String repairType, int ssTableHigherThreshold);
@@ -71,4 +67,7 @@ public interface AutoRepairServiceMBean
 
     public void setRepairByKeyspace(String repairType, boolean repairByKeyspace);
 
+    public void setAutoRepairMaxRetriesCount(String repairType, int retries);
+
+    public void setAutoRepairRetryBackoff(String repairType, String interval);
 }

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -2573,16 +2573,6 @@ public class NodeProbe implements AutoCloseable
         autoRepairProxy.startScheduler();
     }
 
-    public void setAutoRepairMaxRetriesCount(int retries)
-    {
-        autoRepairProxy.setAutoRepairMaxRetriesCount(retries);
-    }
-
-    public void setAutoRepairRetryBackoff(String interval)
-    {
-        autoRepairProxy.setAutoRepairRetryBackoff(interval);
-    }
-
     public void setAutoRepairMinRepairTaskDuration(String duration)
     {
         autoRepairProxy.setAutoRepairMinRepairTaskDuration(duration);
@@ -2646,6 +2636,16 @@ public class NodeProbe implements AutoCloseable
     public void setAutoRepairRepairByKeyspace(String repairType, boolean enabled)
     {
         autoRepairProxy.setRepairByKeyspace(repairType, enabled);
+    }
+
+    public void setAutoRepairMaxRetriesCount(String repairType, int retries)
+    {
+        autoRepairProxy.setAutoRepairMaxRetriesCount(repairType, retries);
+    }
+
+    public void setAutoRepairRetryBackoff(String repairType, String interval)
+    {
+        autoRepairProxy.setAutoRepairRetryBackoff(repairType, interval);
     }
 }
 

--- a/src/java/org/apache/cassandra/tools/nodetool/SetAutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/SetAutoRepairConfig.java
@@ -87,12 +87,6 @@ public class SetAutoRepairConfig extends NodeToolCmd
             case "history_clear_delete_hosts_buffer_interval":
                 probe.setAutoRepairHistoryClearDeleteHostsBufferDuration(paramVal);
                 return;
-            case "repair_max_retries":
-                probe.setAutoRepairMaxRetriesCount(Integer.parseInt(paramVal));
-                return;
-            case "repair_retry_backoff":
-                probe.setAutoRepairRetryBackoff(paramVal);
-                return;
             case "min_repair_task_duration":
                 probe.setAutoRepairMinRepairTaskDuration(paramVal);
                 return;
@@ -162,6 +156,12 @@ public class SetAutoRepairConfig extends NodeToolCmd
                 break;
             case "repair_by_keyspace":
                 probe.setAutoRepairRepairByKeyspace(repairTypeStr, Boolean.parseBoolean(paramVal));
+                break;
+            case "repair_max_retries":
+                probe.setAutoRepairMaxRetriesCount(repairTypeStr, Integer.parseInt(paramVal));
+                break;
+            case "repair_retry_backoff":
+                probe.setAutoRepairRetryBackoff(repairTypeStr, paramVal);
                 break;
             default:
                 throw new IllegalArgumentException("Unknown parameter: " + paramType);

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -488,7 +488,7 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
         config.setMaterializedViewRepairEnabled(repairType, true);
         config.setRepairMinInterval(repairType, "0s");
-        config.setRepairRetryBackoff("0s");
+        config.setRepairRetryBackoff(repairType, "0s");
         config.setAutoRepairTableMaxRepairTime(repairType, "0s");
         AutoRepair.timeFunc = () -> {
             timeFuncCalls++;
@@ -652,7 +652,7 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepair.sleepFunc = (Long duration, TimeUnit unit) -> {
             sleepCalls.getAndIncrement();
             assertEquals(TimeUnit.SECONDS, unit);
-            assertEquals(config.getRepairRetryBackoff().toSeconds(), (long) duration);
+            assertEquals(config.getRepairRetryBackoff(repairType).toSeconds(), (long) duration);
         };
         config.setRepairMinInterval(repairType, "0s");
         AutoRepair.instance.repairStates.put(repairType, autoRepairState);
@@ -660,7 +660,7 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepair.instance.repair(repairType);
 
         // Expect configured retries for each keyspace expected to be repaired
-        assertEquals(config.getRepairMaxRetries()*expectedRepairAssignments, sleepCalls.get());
+        assertEquals(config.getRepairMaxRetries(repairType)*expectedRepairAssignments, sleepCalls.get());
         verify(autoRepairState, times(1)).setSucceededTokenRangesCount(0);
         verify(autoRepairState, times(1)).setSkippedTokenRangesCount(0);
         verify(autoRepairState, times(1)).setFailedTokenRangesCount(expectedRepairAssignments);
@@ -676,7 +676,7 @@ public class AutoRepairParameterizedTest extends CQLTester
         AutoRepair.sleepFunc = (Long duration, TimeUnit unit) -> {
             sleepCalls.getAndIncrement();
             assertEquals(TimeUnit.SECONDS, unit);
-            assertEquals(config.getRepairRetryBackoff().toSeconds(), (long) duration);
+            assertEquals(config.getRepairRetryBackoff(repairType).toSeconds(), (long) duration);
         };
         doAnswer(invocation -> {
             if (sleepCalls.get() == 0)
@@ -691,7 +691,7 @@ public class AutoRepairParameterizedTest extends CQLTester
             return null;
         }).when(repairRunnable).addProgressListener(any());
         config.setRepairMinInterval(repairType, "0s");
-        config.setRepairMaxRetries(1);
+        config.setRepairMaxRetries(repairType, 1);
         AutoRepair.instance.repairStates.put(repairType, autoRepairState);
         AutoRepair.instance.repair(repairType);
 
@@ -865,7 +865,7 @@ public class AutoRepairParameterizedTest extends CQLTester
             return runnable;
         }).when(spyState).getRepairRunnable(any(), any(), any(), anyBoolean());
         when(spyState.getLastRepairTime()).thenReturn((long) 0);
-        AutoRepairService.instance.getAutoRepairConfig().setRepairMaxRetries(0);
+        AutoRepairService.instance.getAutoRepairConfig().setRepairMaxRetries(repairType, 0);
         AutoRepair.instance.repairStates.put(repairType, spyState);
 
         AutoRepair.instance.repair(repairType);

--- a/test/unit/org/apache/cassandra/service/AutoRepairServiceBasicTest.java
+++ b/test/unit/org/apache/cassandra/service/AutoRepairServiceBasicTest.java
@@ -75,17 +75,17 @@ public class AutoRepairServiceBasicTest extends CQLTester
     @Test
     public void testsetAutoRepairMaxRetriesCount()
     {
-        autoRepairService.setAutoRepairMaxRetriesCount(101);
+        autoRepairService.setAutoRepairMaxRetriesCount(AutoRepairConfig.RepairType.INCREMENTAL.name(), 101);
 
-        assertEquals(101, config.getRepairMaxRetries());
+        assertEquals(101, config.getRepairMaxRetries(AutoRepairConfig.RepairType.INCREMENTAL));
     }
 
     @Test
     public void testsetAutoRepairRetryBackoffInSec()
     {
-        autoRepairService.setAutoRepairRetryBackoff("102s");
+        autoRepairService.setAutoRepairRetryBackoff(AutoRepairConfig.RepairType.INCREMENTAL.name(), "102s");
 
-        assertEquals(102, config.getRepairRetryBackoff().toSeconds());
+        assertEquals(102, config.getRepairRetryBackoff(AutoRepairConfig.RepairType.INCREMENTAL).toSeconds());
     }
 
     @Test(expected = ConfigurationException.class)

--- a/test/unit/org/apache/cassandra/tools/nodetool/SetAutoRepairConfigTest.java
+++ b/test/unit/org/apache/cassandra/tools/nodetool/SetAutoRepairConfigTest.java
@@ -96,26 +96,6 @@ public class SetAutoRepairConfigTest
         }
 
         @Test
-        public void testRepairMaxRetries()
-        {
-            cmd.args = ImmutableList.of("repair_max_retries", "2");
-
-            cmd.execute(probe);
-
-            verify(probe, times(1)).setAutoRepairMaxRetriesCount(2);
-        }
-
-        @Test
-        public void testRetryBackoffInSec()
-        {
-            cmd.args = ImmutableList.of("repair_retry_backoff", "3s");
-
-            cmd.execute(probe);
-
-            verify(probe, times(1)).setAutoRepairRetryBackoff("3s");
-        }
-
-        @Test
         public void testStartScheduler()
         {
             cmd.args = ImmutableList.of("start_scheduler", "false");
@@ -286,7 +266,9 @@ public class SetAutoRepairConfigTest
             forEachRepairType("parallel_repair_percentage", "7", (type) -> verify(probe, times(1)).setAutoRepairParallelRepairPercentage(type.name(), 7)),
             forEachRepairType("materialized_view_repair_enabled", "true", (type) -> verify(probe, times(1)).setAutoRepairMaterializedViewRepairEnabled(type.name(), true)),
             forEachRepairType("ignore_dcs", "dc1,dc2", (type) -> verify(probe, times(1)).setAutoRepairIgnoreDCs(type.name(), ImmutableSet.of("dc1", "dc2"))),
-            forEachRepairType("token_range_splitter.max_bytes_per_schedule", "500GiB", (type) -> verify(probe, times(1)).setAutoRepairTokenRangeSplitterParameter(type.name(), "max_bytes_per_schedule", "500GiB"))
+            forEachRepairType("token_range_splitter.max_bytes_per_schedule", "500GiB", (type) -> verify(probe, times(1)).setAutoRepairTokenRangeSplitterParameter(type.name(), "max_bytes_per_schedule", "500GiB")),
+            forEachRepairType("repair_max_retries", "3", (type) -> verify(probe, times(1)).setAutoRepairMaxRetriesCount(type.name(), 3)),
+            forEachRepairType("repair_retry_backoff", "60s", (type) -> verify(probe, times(1)).setAutoRepairRetryBackoff(type.name(), "60s"))
             ).flatMap(Function.identity()).collect(Collectors.toList());
         }
 


### PR DESCRIPTION
For CASSANDRA-20430

Moves the auto-repair retry policy config from the root level of the auto-repair config to the repair-type level. This will allow configuring a different retry policy for each repair type, such as no retries for incremental repair and 3 retries with 1 min backoff for full repair.

**Tests:**

```
$ ./nodetool setautorepairconfig -t full enabled true
$ ./nodetool setautorepairconfig -t incremental enabled true
$ ./nodetool getautorepairconfig
repair scheduler configuration:
	repair_check_interval: 5m
	repair_task_min_duration: 5s
	history_clear_delete_hosts_buffer_interval: 2h
configuration for repair_type: full
	enabled: true
                 ...
	repair_max_retries: 3
	repair_retry_backoff: 30s
                 ...
configuration for repair_type: incremental
	enabled: true
                 ...
	repair_max_retries: 3
	repair_retry_backoff: 30s
                 ...
configuration for repair_type: preview_repaired
	enabled: false

$ ./nodetool setautorepairconfig -t incremental repair_max_retries 4
$ ./nodetool setautorepairconfig -t incremental repair_retry_backoff 2m
$ ./nodetool getautorepairconfig
repair scheduler configuration:
	repair_check_interval: 5m
	repair_task_min_duration: 5s
	history_clear_delete_hosts_buffer_interval: 2h
configuration for repair_type: full
	enabled: true
                 ...
	repair_max_retries: 3
	repair_retry_backoff: 30s
                 ...
configuration for repair_type: incremental
	enabled: true
                 ...
	repair_max_retries: 4
	repair_retry_backoff: 2m
                 ...
configuration for repair_type: preview_repaired
	enabled: false
```