### PR TITLE
Avoid returning MY_TURN when replicas are actively taking their turn

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -2734,6 +2734,15 @@ storage_compatibility_mode: NONE
 #     # Percentage of nodes in the cluster running repair in parallel. If parallel_repair_count is set, the larger value
 #     # is used.
 #     parallel_repair_percentage: 3
+#     # Whether to allow a node to take its turn running repair while one or more of its replicas are running repair.
+#     # Defaults to false, as running repairs concurrently on replicas can increase load and also cause anticompaction
+#     # conflicts while running incremental repair.
+#     allow_parallel_replica_repair: false
+#     # An addition to allow_parallel_replica_repair that also blocks repairs when replicas (including this node itself)
+#     # are repairing in any schedule. For example, if a replica is executing full repairs, a value of false will
+#     # prevent starting incremental repairs for this node. Defaults to true and is only evaluated when
+#     # allow_parallel_replica_repair is false.
+#     allow_parallel_replica_repair_across_schedules: true
 #     # Repairs materialized views if true.
 #     materialized_view_repair_enabled: false
 #     # Delay before starting repairs after a node restarts to avoid repairs starting immediately after a restart.

--- a/conf/cassandra_latest.yaml
+++ b/conf/cassandra_latest.yaml
@@ -2451,6 +2451,15 @@ storage_compatibility_mode: NONE
 #     # Percentage of nodes in the cluster running repair in parallel. If parallel_repair_count is set, the larger value
 #     # is used.
 #     parallel_repair_percentage: 3
+#     # Whether to allow a node to take its turn running repair while one or more of its replicas are running repair.
+#     # Defaults to false, as running repairs concurrently on replicas can increase load and also cause anticompaction
+#     # conflicts while running incremental repair.
+#     allow_parallel_replica_repair: false
+#     # An addition to allow_parallel_replica_repair that also blocks repairs when replicas (including this node itself)
+#     # are repairing in any schedule. For example, if a replica is executing full repairs, a value of false will
+#     # prevent starting incremental repairs for this node. Defaults to true and is only evaluated when
+#     # allow_parallel_replica_repair is false.
+#     allow_parallel_replica_repair_across_schedules: true
 #     # Repairs materialized views if true.
 #     materialized_view_repair_enabled: false
 #     # Delay before starting repairs after a node restarts to avoid repairs starting immediately after a restart.

--- a/doc/modules/cassandra/pages/managing/operating/auto_repair.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/auto_repair.adoc
@@ -195,6 +195,13 @@ the -j option in nodetool repair.
 larger value is used.
 | parallel_repair_percentage | 3 | Percentage of nodes in the cluster running repair in parallel. If
 `parallel_repair_count is set`, the larger value is used.
+| allow_parallel_replica_repair | false | Whether to allow a node to take its turn running repair while one or more of
+its replicas are running repair. Defaults to false, as running repairs concurrently on replicas can increase load and
+also cause anticompaction conflicts while running incremental repair.
+| allow_parallel_replica_repair_across_schedules | true | An addition to allow_parallel_repair that also blocks repairs
+when replicas (including this node itself) are repairing in any schedule.
+For example, if a replica is executing full repairs, a value of false will prevent starting incremental repairs for this
+node. Defaults to true and is only evaluated when allow_parallel_replica_repair is false.
 | materialized_view_repair_enabled | false | Repairs materialized views if true.
 | initial_scheduler_delay | 5m | Delay before starting repairs after a node restarts to avoid repairs starting
 immediately after a restart.

--- a/doc/modules/cassandra/pages/managing/operating/metrics.adoc
+++ b/doc/modules/cassandra/pages/managing/operating/metrics.adoc
@@ -1114,6 +1114,9 @@ the entire Cassandra cluster in seconds
 |LongestUnrepairedSec |Gauge<Integer> |Time since the last repair
 ran on the node in seconds
 
+|RepairStartLagSec|Gauge<Integer> |If a repair has not run within min_repair_interval, how long past this value since
+repairs last completed.  Useful for determining if repairs are behind schedule.
+
 |SucceededTokenRangesCount |Gauge<Integer> |Number of token ranges successfully repaired on the node
 
 |FailedTokenRangesCount |Gauge<Integer> |Number of token ranges failed to repair on the node
@@ -1135,9 +1138,13 @@ the automated repair has been disabled on the node
 |RepairTurnMyTurnDueToPriority |Counter |Represents the node's turn to repair
 due to priority set in the automated repair
 
-|RepairTurnMyTurnForceRepair |Counter |Represents the node's turn to repair
-due to force repair set in the automated repair
+|RepairDelayedByReplica |Counter |Represents occurrences of a node's turn being
+delayed because a replica was currently taking its turn. Only revelent if
+`allow_parallel_replica_repair` is false.
 
+|RepairDelayedBySchedule |Counter |Represents occurrences of a node's turn being
+delayed because it was already being repaired in another schedule. Only relevent
+if `allow_parallel_replica_repair_across_schedules` is false.
 
 |===
 

--- a/src/java/org/apache/cassandra/metrics/AutoRepairMetrics.java
+++ b/src/java/org/apache/cassandra/metrics/AutoRepairMetrics.java
@@ -23,7 +23,9 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.cassandra.repair.autorepair.AutoRepairConfig.RepairType;
 import org.apache.cassandra.repair.autorepair.AutoRepairUtils;
 import org.apache.cassandra.repair.autorepair.AutoRepair;
+import org.apache.cassandra.service.AutoRepairService;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.cassandra.metrics.CassandraMetricsRegistry.Metrics;
 import static org.apache.cassandra.utils.LocalizeString.toLowerCaseLocalized;
 
@@ -37,6 +39,7 @@ public class AutoRepairMetrics
     public final Gauge<Integer> nodeRepairTimeInSec;
     public final Gauge<Integer> clusterRepairTimeInSec;
     public final Gauge<Integer> longestUnrepairedSec;
+    public final Gauge<Integer> repairStartLagSec;
     public final Gauge<Integer> succeededTokenRangesCount;
     public final Gauge<Integer> failedTokenRangesCount;
     public final Gauge<Integer> skippedTokenRangesCount;
@@ -46,8 +49,16 @@ public class AutoRepairMetrics
     public Counter repairTurnMyTurn;
     public Counter repairTurnMyTurnDueToPriority;
     public Counter repairTurnMyTurnForceRepair;
+    public Counter repairDelayedByReplica;
+    public Counter repairDelayedBySchedule;
+
+    private final RepairType repairType;
+
+    private volatile int repairStartLagSecVal;
+
     public AutoRepairMetrics(RepairType repairType)
     {
+        this.repairType = repairType;
         AutoRepairMetricsFactory factory = new AutoRepairMetricsFactory(repairType);
 
         repairsInProgress = Metrics.register(factory.createMetricName("RepairsInProgress"), new Gauge<Integer>()
@@ -98,6 +109,14 @@ public class AutoRepairMetrics
             }
         });
 
+        repairStartLagSec = Metrics.register(factory.createMetricName("RepairStartLagSec"), new Gauge<Integer>()
+        {
+            public Integer getValue()
+            {
+                return repairStartLagSecVal;
+            }
+        });
+
         succeededTokenRangesCount = Metrics.register(factory.createMetricName("SucceededTokenRangesCount"), new Gauge<Integer>()
         {
             public Integer getValue()
@@ -117,6 +136,9 @@ public class AutoRepairMetrics
         repairTurnMyTurn = Metrics.counter(factory.createMetricName("RepairTurnMyTurn"));
         repairTurnMyTurnDueToPriority = Metrics.counter(factory.createMetricName("RepairTurnMyTurnDueToPriority"));
         repairTurnMyTurnForceRepair = Metrics.counter(factory.createMetricName("RepairTurnMyTurnForceRepair"));
+
+        repairDelayedByReplica = Metrics.counter(factory.createMetricName("RepairDelayedByReplica"));
+        repairDelayedBySchedule = Metrics.counter(factory.createMetricName("RepairDelayedBySchedule"));
 
         totalMVTablesConsideredForRepair = Metrics.register(factory.createMetricName("TotalMVTablesConsideredForRepair"), new Gauge<Integer>()
         {
@@ -151,6 +173,23 @@ public class AutoRepairMetrics
             default:
                 throw new RuntimeException(String.format("Unrecoginized turn: %s", turn.name()));
         }
+        this.repairStartLagSecVal = 0;
+    }
+
+    /**
+     * Record perceived lag in scheduling repair.
+     * <p/>
+     * Takes the current time and subtracts it from the given last repair finish time.  It then compares the difference
+     * with the min repair interval for this repair type, and if that value is greater than 0, records it.
+     */
+    public void recordRepairStartLag(long lastFinishTimeInMs)
+    {
+        long now = AutoRepair.instance.currentTimeMs();
+        long deltaFinish = now - lastFinishTimeInMs;
+        long deltaMinRepairInterval = deltaFinish - AutoRepairService.instance
+                                                    .getAutoRepairConfig().getRepairMinInterval(repairType)
+                                                    .toMilliseconds();
+        this.repairStartLagSecVal = deltaMinRepairInterval > 0 ? (int) MILLISECONDS.toSeconds(deltaMinRepairInterval) : 0;
     }
 
     @VisibleForTesting

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -154,6 +154,14 @@ public class AutoRepair
         repairExecutors.get(repairType).submit(() -> repair(repairType));
     }
 
+    /**
+     * @return The current observed system time in ms.
+     */
+    public long currentTimeMs()
+    {
+        return timeFunc.get();
+    }
+
     // repair runs a repair session of the given type synchronously.
     public void repair(AutoRepairConfig.RepairType repairType)
     {
@@ -179,6 +187,13 @@ public class AutoRepair
 
             //consistency level to use for local query
             UUID myId = StorageService.instance.getHostIdForEndpoint(FBUtilities.getBroadcastAddressAndPort());
+
+            // If it's too soon to run repair, don't bother checking if it's our turn.
+            if (tooSoonToRunRepair(repairType, repairState, config, myId))
+            {
+                return;
+            }
+
             RepairTurn turn = AutoRepairUtils.myTurnToRunRepair(repairType, myId);
             if (turn == MY_TURN || turn == MY_TURN_DUE_TO_PRIORITY || turn == MY_TURN_FORCE_REPAIR)
             {
@@ -189,10 +204,6 @@ public class AutoRepair
                 // When doing force repair, we want to repair without -pr.
                 boolean primaryRangeOnly = config.getRepairPrimaryTokenRangeOnly(repairType)
                                            && turn != MY_TURN_FORCE_REPAIR;
-                if (tooSoonToRunRepair(repairType, repairState, config, myId))
-                {
-                    return;
-                }
 
                 long startTime = timeFunc.get();
                 logger.info("My host id: {}, my turn to run repair...repair primary-ranges only? {}", myId,
@@ -387,7 +398,8 @@ public class AutoRepair
             // we should check for the node's repair history in the DB
             repairState.setLastRepairTime(AutoRepairUtils.getLastRepairTimeForNode(repairType, myId));
         }
-        /** check if it is too soon to run repair. one of the reason we
+        /*
+         * check if it is too soon to run repair. one of the reason we
          * should not run frequent repair is that repair triggers
          * memtable flush
          */

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
@@ -275,6 +275,26 @@ public class AutoRepairConfig implements Serializable
         getOptions(repairType).parallel_repair_count = count;
     }
 
+    public boolean getAllowParallelReplicaRepair(RepairType repairType)
+    {
+        return applyOverrides(repairType, opt -> opt.allow_parallel_replica_repair);
+    }
+
+    public void setAllowParallelReplicaRepair(RepairType repairType, boolean enabled)
+    {
+        getOptions(repairType).allow_parallel_replica_repair = enabled;
+    }
+
+    public boolean getAllowParallelReplicaRepairAcrossSchedules(RepairType repairType)
+    {
+        return applyOverrides(repairType, opt -> opt.allow_parallel_replica_repair_across_schedules);
+    }
+
+    public void setAllowParallelReplicaRepairAcrossSchedules(RepairType repairType, boolean enabled)
+    {
+        getOptions(repairType).allow_parallel_replica_repair_across_schedules = enabled;
+    }
+
     public boolean getMaterializedViewRepairEnabled(RepairType repairType)
     {
         return applyOverrides(repairType, opt -> opt.materialized_view_repair_enabled);
@@ -440,6 +460,8 @@ public class AutoRepairConfig implements Serializable
             opts.number_of_repair_threads = 1;
             opts.parallel_repair_count = 3;
             opts.parallel_repair_percentage = 3;
+            opts.allow_parallel_replica_repair = false;
+            opts.allow_parallel_replica_repair_across_schedules = true;
             opts.sstable_upper_threshold = 10000;
             opts.ignore_dcs = new HashSet<>();
             opts.repair_primary_token_range_only = true;
@@ -467,6 +489,15 @@ public class AutoRepairConfig implements Serializable
         // Percentage of nodes in the cluster running repair in parallel. If parallel_repair_count is set, the larger value
         // is used. Recommendation is that the repair cycle on the cluster should finish within gc_grace_seconds.
         public volatile Integer parallel_repair_percentage;
+        // Whether to allow a node to take its turn running repair while one or more of its replicas are running repair.
+        // Defaults to false, as running repairs concurrently on replicas can increase load and also cause
+        // anticompaction conflicts while running incremental repair.
+        public volatile Boolean allow_parallel_replica_repair;
+        // An addition to allow_parallel_replica_repair that also blocks repairs when replicas (including this node itself)
+        // are repairing in any schedule. For example, if a replica is executing full repairs, a value of false will
+        // prevent starting incremental repairs for this node. Defaults to true and is only evaluated when
+        // allow_parallel_replica_repair is false.
+        public volatile Boolean allow_parallel_replica_repair_across_schedules;
         // Threshold to skip repairing tables with too many SSTables. Defaults to 10,000 SSTables to avoid penalizing good
         // tables.
         public volatile Integer sstable_upper_threshold;
@@ -514,6 +545,8 @@ public class AutoRepairConfig implements Serializable
                    ", number_of_repair_threads=" + number_of_repair_threads +
                    ", parallel_repair_count=" + parallel_repair_count +
                    ", parallel_repair_percentage=" + parallel_repair_percentage +
+                   ", allow_parallel_replica_repair=" + allow_parallel_replica_repair +
+                   ", allow_parallel_replica_repair_across_schedules=" + allow_parallel_replica_repair_across_schedules +
                    ", sstable_upper_threshold=" + sstable_upper_threshold +
                    ", min_repair_interval=" + min_repair_interval +
                    ", ignore_dcs=" + ignore_dcs +

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairUtils.java
@@ -21,22 +21,33 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 
 import org.apache.cassandra.dht.Range;
 import org.apache.cassandra.dht.Splitter;
 import org.apache.cassandra.dht.Token;
+import org.apache.cassandra.locator.EndpointsByRange;
+import org.apache.cassandra.locator.EndpointsForRange;
 import org.apache.cassandra.locator.LocalStrategy;
 
 import org.slf4j.Logger;
@@ -57,6 +68,9 @@ import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.locator.InetAddressAndPort;
 import org.apache.cassandra.locator.MetaStrategy;
 import org.apache.cassandra.locator.NetworkTopologyStrategy;
+import org.apache.cassandra.locator.RangesAtEndpoint;
+import org.apache.cassandra.locator.Replica;
+import org.apache.cassandra.metrics.AutoRepairMetricsManager;
 import org.apache.cassandra.schema.Schema;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.SystemDistributedKeyspace;
@@ -69,6 +83,7 @@ import org.apache.cassandra.service.ClientState;
 import org.apache.cassandra.service.QueryState;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.tcm.ClusterMetadata;
+import org.apache.cassandra.tcm.membership.Directory;
 import org.apache.cassandra.tcm.membership.NodeAddresses;
 import org.apache.cassandra.tcm.membership.NodeId;
 import org.apache.cassandra.transport.Dispatcher;
@@ -261,9 +276,10 @@ public class AutoRepairUtils
         public Set<UUID> hostIdsWithOnGoingRepair;  // hosts that is running repair
         public Set<UUID> hostIdsWithOnGoingForceRepair; // hosts that is running repair because of force repair
         Set<UUID> priority;
+        public AutoRepairHistory myRepairHistory;
         List<AutoRepairHistory> historiesWithoutOnGoingRepair;  // hosts that is NOT running repair
 
-        public CurrentRepairStatus(List<AutoRepairHistory> repairHistories, Set<UUID> priority)
+        public CurrentRepairStatus(List<AutoRepairHistory> repairHistories, Set<UUID> priority, UUID myId)
         {
             hostIdsWithOnGoingRepair = new HashSet<>();
             hostIdsWithOnGoingForceRepair = new HashSet<>();
@@ -286,8 +302,17 @@ public class AutoRepairUtils
                 {
                     historiesWithoutOnGoingRepair.add(history);
                 }
+                if (history.hostId.equals(myId))
+                {
+                    myRepairHistory = history;
+                }
             }
             this.priority = priority;
+        }
+
+        public Set<UUID> getAllHostsWithOngoingRepair()
+        {
+           return Sets.union(hostIdsWithOnGoingRepair, hostIdsWithOnGoingForceRepair);
         }
 
         public String toString()
@@ -297,6 +322,7 @@ public class AutoRepairUtils
                               add("hostIdsWithOnGoingForceRepair", hostIdsWithOnGoingForceRepair).
                               add("historiesWithoutOnGoingRepair", historiesWithoutOnGoingRepair).
                               add("priority", priority).
+                              add("myRepairHistory", myRepairHistory).
                               toString();
         }
     }
@@ -311,7 +337,7 @@ public class AutoRepairUtils
         repairHistoryResult = UntypedResultSet.create(repairStatusRows.result);
 
         List<AutoRepairHistory> repairHistories = new ArrayList<>();
-        if (repairHistoryResult.size() > 0)
+        if (!repairHistoryResult.isEmpty())
         {
             for (UntypedResultSet.Row row : repairHistoryResult)
             {
@@ -323,7 +349,7 @@ public class AutoRepairUtils
                 long lastRepairFinishTime = row.getLong(COL_REPAIR_FINISH_TS, 0);
                 Set<UUID> deleteHosts = row.getSet(COL_DELETE_HOSTS, UUIDType.instance);
                 long deleteHostsUpdateTime = row.getLong(COL_DELETE_HOSTS_UPDATE_TIME, 0);
-                Boolean forceRepair = row.has(COL_FORCE_REPAIR) ? row.getBoolean(COL_FORCE_REPAIR) : false;
+                boolean forceRepair = row.has(COL_FORCE_REPAIR) && row.getBoolean(COL_FORCE_REPAIR);
                 repairHistories.add(new AutoRepairHistory(hostId, repairTurn, lastRepairStartTime, lastRepairFinishTime,
                                                           deleteHosts, deleteHostsUpdateTime, forceRepair));
             }
@@ -373,12 +399,6 @@ public class AutoRepairUtils
         logger.info("Set force repair repair type: {}, node: {}", repairType, hostId);
     }
 
-    public static CurrentRepairStatus getCurrentRepairStatus(RepairType repairType)
-    {
-        List<AutoRepairHistory> autoRepairHistories = getAutoRepairHistory(repairType);
-        return getCurrentRepairStatus(repairType, autoRepairHistories);
-    }
-
     public static long getLastRepairTimeForNode(RepairType repairType, UUID hostId)
     {
         ResultMessage.Rows rows = selectLastRepairTimeForNode.execute(QueryState.forInternalCalls(),
@@ -395,13 +415,12 @@ public class AutoRepairUtils
         return repairTime.one().getLong(COL_REPAIR_FINISH_TS);
     }
 
-    public static CurrentRepairStatus getCurrentRepairStatus(RepairType repairType, List<AutoRepairHistory> autoRepairHistories)
+    @VisibleForTesting
+    public static CurrentRepairStatus getCurrentRepairStatus(RepairType repairType, List<AutoRepairHistory> autoRepairHistories, UUID myId)
     {
         if (autoRepairHistories != null)
         {
-            CurrentRepairStatus status = new CurrentRepairStatus(autoRepairHistories, getPriorityHostIds(repairType));
-
-            return status;
+            return new CurrentRepairStatus(autoRepairHistories, getPriorityHostIds(repairType), myId);
         }
         return null;
     }
@@ -418,7 +437,8 @@ public class AutoRepairUtils
                 logger.info("Ignore node {} because its datacenter is {}", node, nodeDC);
                 continue;
             }
-            /** Check if endpoint state exists in gossip or not. If it
+            /*
+             * Check if endpoint state exists in gossip or not. If it
              * does not then this maybe a ghost node so ignore it
              */
             if (Gossiper.instance.isAlive(node.broadcastAddress))
@@ -445,6 +465,262 @@ public class AutoRepairUtils
     {
         List<AutoRepairHistory> autoRepairHistories = getAutoRepairHistory(repairType);
         return getHostWithLongestUnrepairTime(autoRepairHistories);
+    }
+
+    /**
+     * Convenience method to resolve the broadcast address of a host id from {@link ClusterMetadata}
+     * @return broadcast address if it exists in CMS, otherwise null.
+     */
+    @Nullable
+    private static InetAddressAndPort getBroadcastAddress(UUID hostId)
+    {
+        Directory directory = ClusterMetadata.current().directory;
+
+        NodeId nodeId = directory.nodeIdFromHostId(hostId);
+        if (nodeId != null)
+        {
+            NodeAddresses nodeAddresses = directory.getNodeAddresses(nodeId);
+            if (nodeAddresses != null)
+            {
+                return nodeAddresses.broadcastAddress;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return Map of broadcast address to host id, if a broadcast address cannot be found for a host, it is
+     * not included in the map.
+     */
+    private static Map<InetAddressAndPort, UUID> getBroadcastAddressToHostIdMap(Set<UUID> hosts)
+    {
+        // Get a mapping of endpoint : host id
+        Map<InetAddressAndPort, UUID> broadcastAddressMap = new HashMap<>(hosts.size());
+        for (UUID hostId : hosts)
+        {
+            InetAddressAndPort broadcastAddress = getBroadcastAddress(hostId);
+            if (broadcastAddress == null)
+            {
+                logger.warn("Could not resolve broadcast address from host id {} in ClusterMetadata can't accurately " +
+                            "determine if this node is a replica of the local node.", hostId);
+            }
+            else
+            {
+                broadcastAddressMap.put(broadcastAddress, hostId);
+            }
+        }
+        return broadcastAddressMap;
+    }
+
+    /**
+     * @return Mapping of unique replication strategy to keyspaces using that strategy that we care about repairing.
+     */
+    private static Map<AbstractReplicationStrategy, List<String>> getReplicationStrategies()
+    {
+        // Collect all unique replication strategies among all keyspaces.
+        Map<AbstractReplicationStrategy, List<String>> replicationStrategies = new HashMap<>();
+        for (Keyspace keyspace : Keyspace.all())
+        {
+            if (AutoRepairUtils.shouldConsiderKeyspace(keyspace))
+            {
+                replicationStrategies.computeIfAbsent(keyspace.getReplicationStrategy(), k -> new ArrayList<>())
+                                     .add(keyspace.getName());
+            }
+        }
+        return replicationStrategies;
+    }
+
+    /**
+     * Collects all hosts being repaired among all active repair schedules and their schedule if
+     * {@link AutoRepairConfig#getAllowParallelReplicaRepairAcrossSchedules(RepairType)} is true for this repairType.
+     * Accepts the currently evaluated repairType's schedule as an optimization to avoid grabbing its repair status an
+     * additional time.
+     *
+     * @param myRepairType The repair type schedule being evaluated.
+     * @param myRepairStatus The repair status for that repair type.
+     * @return All hosts among active schedules currently being repaired.
+     */
+    private static Map<UUID, RepairType> getHostsBeingRepaired(RepairType myRepairType, CurrentRepairStatus myRepairStatus)
+    {
+        AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
+
+        Map<UUID, RepairType> hostsBeingRepaired = myRepairStatus.getAllHostsWithOngoingRepair().stream()
+                                                                 .collect(Collectors.toMap((h) -> h, (v) -> myRepairType));
+
+        // If we don't allow repairing across schedules, iterate over other enabled schedules and include hosts
+        // actively being repaired.
+        if (!config.getAllowParallelReplicaRepairAcrossSchedules(myRepairType))
+        {
+            for (RepairType repairType : RepairType.values())
+            {
+                if (myRepairType == repairType)
+                    continue;
+
+                if (config.isAutoRepairEnabled(repairType))
+                {
+                    CurrentRepairStatus repairStatus = getCurrentRepairStatus(repairType, getAutoRepairHistory(repairType), null);
+                    if (repairStatus != null)
+                    {
+                        for (UUID hostId : repairStatus.getAllHostsWithOngoingRepair())
+                        {
+                            hostsBeingRepaired.putIfAbsent(hostId, repairType);
+                        }
+                    }
+                }
+            }
+        }
+        return hostsBeingRepaired;
+    }
+
+    /**
+     * Identifies the most eligible host to repair for nodes preceding or equal to this nodes' lastRepairFinishTime.
+     * The criteria for this is to find the node with the oldest last repair finish time of which none of its replicas
+     * are currently under repair.
+     * @return The most eligible host to repair or null if no candidates before and including this nodes' current repair status.
+     */
+    @VisibleForTesting
+    public static AutoRepairHistory getMostEligibleHostToRepair(RepairType repairType, CurrentRepairStatus currentRepairStatus, UUID myId)
+    {
+        // 0. If this repairType allows parallel replica repair, short circuit and return the host with the longest unrepair time
+        AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
+        if (config.getAllowParallelReplicaRepair(repairType))
+        {
+            return getHostWithLongestUnrepairTime(currentRepairStatus.historiesWithoutOnGoingRepair);
+        }
+
+        // 1. Sort repair histories from oldest completed to newest
+        Stream<AutoRepairHistory> finishedRepairHistories = currentRepairStatus.historiesWithoutOnGoingRepair
+                                                            .stream()
+                                                            .sorted(Comparator.comparingLong(h -> h.lastRepairFinishTime));
+
+        // 2. Optimization: Truncate repair histories after myId so we don't evaluate anything more recent as if we
+        // aren't interested in anything that isn't this node.
+        final AtomicBoolean myHistoryFound = new AtomicBoolean(false);
+        finishedRepairHistories = finishedRepairHistories.takeWhile((history) -> {
+            if (myHistoryFound.get()) return false;
+
+            myHistoryFound.set(history.hostId.equals(myId));
+            return true;
+        });
+
+        // If there are any hosts with ongoing repair, filter the repair histories to not include nodes whose replicas
+        // are ongoing repair.
+        Map<UUID, RepairType> hostsBeingRepairedToRepairType = getHostsBeingRepaired(repairType, currentRepairStatus);
+
+        // 3. If I am already actively being repaired in another schedule, defer submitting repairs;  if already
+        // repairing for this type, return node so it can take its turn.
+        RepairType alreadyRepairingType = hostsBeingRepairedToRepairType.get(myId);
+        if (alreadyRepairingType != null)
+        {
+            if (repairType != alreadyRepairingType)
+            {
+                logger.info("Deferring repair because I am already actively repairing in schedule {}", hostsBeingRepairedToRepairType.get(myId));
+                AutoRepairMetricsManager.getMetrics(repairType).repairDelayedBySchedule.inc();
+                return null;
+            }
+            else if (currentRepairStatus.myRepairHistory != null)
+            {
+                // if the repair type matches this repair, assume the node was restarted while repairing, return node
+                // so it can take its turn.
+                logAlreadyMyTurn();
+                return currentRepairStatus.myRepairHistory;
+            }
+        }
+
+        if (!hostsBeingRepairedToRepairType.isEmpty())
+        {
+            // 4. Extract InetAddresses for each UUID as replicas are identified by their address.
+            Map<InetAddressAndPort, UUID> hostsBeingRepaired = getBroadcastAddressToHostIdMap(hostsBeingRepairedToRepairType.keySet());
+
+            // 5. Collect unique replication strategies and group them up with their keyspaces.
+            Map<AbstractReplicationStrategy, List<String>> replicationStrategies = getReplicationStrategies();
+
+            // 6. Filter out repair histories who have a replica being repaired, note that this is lazy, given the stream
+            //    is completed using findFirst, it should stop as soon as the matching criteria is met.
+            finishedRepairHistories = finishedRepairHistories.filter((history) -> !hasReplicaWithOngoingRepair(history,
+                                                                                                               myId,
+                                                                                                               repairType,
+                                                                                                               hostsBeingRepaired,
+                                                                                                               hostsBeingRepairedToRepairType,
+                                                                                                               replicationStrategies));
+        }
+
+        // 7. Select the first (oldest lastRepairFinishTime) repair history without replicas being repaired
+        return finishedRepairHistories.findFirst().orElse(null);
+    }
+
+
+    /**
+     * @return Whether the host for the given eligibleRepairHistory has any replicas in hostsBeingRepaired.
+     * @param eligibleHistory History of node to check
+     * @param myId Host id of this node, if the repair history is for this node, additional logging will take place.
+     * @param myRepairType repair type being evaluated
+     * @param hostsBeingRepaired Hosts being repaired.
+     * @param hostIdToRepairType mapping of hosts being repaired to the repair type its being repaired for.
+     * @param replicationStrategies Mapping of unique replication strategies to keyspaces having that strategy.
+     */
+    private static boolean hasReplicaWithOngoingRepair(AutoRepairHistory eligibleHistory,
+                                                       UUID myId,
+                                                       RepairType myRepairType,
+                                                       Map<InetAddressAndPort, UUID> hostsBeingRepaired,
+                                                       Map<UUID, RepairType> hostIdToRepairType,
+                                                       Map<AbstractReplicationStrategy, List<String>> replicationStrategies)
+    {
+        // If no broadcast address found for this host id in cluster metadata, just skip it, a node should always
+        // see itself in cluster metadata.
+        InetAddressAndPort eligibleBroadcastAddress = getBroadcastAddress(eligibleHistory.hostId);
+        if (eligibleBroadcastAddress == null)
+        {
+            return true;
+        }
+
+        // For each replication strategy, determine if host being repaired is a replica of the local node.
+        for (Map.Entry<AbstractReplicationStrategy, List<String>> entry : replicationStrategies.entrySet())
+        {
+            AbstractReplicationStrategy replicationStrategy = entry.getKey();
+            EndpointsByRange endpointsByRange = replicationStrategy.getRangeAddresses(ClusterMetadata.current());
+
+            // get ranges of the eligible address for the given replication strategy.
+            RangesAtEndpoint rangesAtEndpoint = StorageService.instance.getReplicas(replicationStrategy, eligibleBroadcastAddress);
+            for (Replica replica : rangesAtEndpoint)
+            {
+                // get the endpoints involved in this range.
+                EndpointsForRange endpointsForRange = endpointsByRange.get(replica.range());
+                // For each host in this range...
+                for (InetAddressAndPort inetAddressAndPort : endpointsForRange.endpoints())
+                {
+                    // If the address of the node in the range belongs to a host being repaired, return true.
+                    UUID hostId = hostsBeingRepaired.get(inetAddressAndPort);
+                    if (hostId != null)
+                    {
+                        // log if the repair history matches the current running node.
+                        InetAddressAndPort myBroadcastAddress = getBroadcastAddress(myId);
+                        if (myBroadcastAddress != null && myBroadcastAddress.equals(eligibleBroadcastAddress))
+                        {
+                            logger.info("Deferring repair because replica {} ({}) with shared ranges for " +
+                                        "{} keyspace(s) (e.g. {}) is currently taking its turn for schedule {}",
+                                        hostId, inetAddressAndPort, entry.getValue().size(), entry.getValue().get(0),
+                                        hostIdToRepairType.get(hostId));
+                            AutoRepairMetricsManager.getMetrics(myRepairType).repairDelayedByReplica.inc();
+                        }
+                        else if (logger.isDebugEnabled())
+                        {
+                            logger.debug("Not considering node {} ({}) for repair as it has replica {} ({}) with " +
+                                         "shared ranges for {} keyspace(s) (e.g. {}) which is currently taking its " +
+                                         "turn for schedule {}",
+                                         eligibleHistory.hostId, eligibleBroadcastAddress,
+                                         hostId, inetAddressAndPort, entry.getValue().size(), entry.getValue().get(0),
+                                         hostIdToRepairType.get(hostId));
+
+                        }
+                        return true;
+                    }
+                }
+            }
+        }
+
+        // No replicas found of eligible host.
+        return false;
     }
 
     private static AutoRepairHistory getHostWithLongestUnrepairTime(List<AutoRepairHistory> autoRepairHistories)
@@ -480,6 +756,12 @@ public class AutoRepairUtils
         return Math.max(1, value);
     }
 
+    private static void logAlreadyMyTurn()
+    {
+        logger.warn("This node already was considered to having an ongoing repair for this repair type, must have " +
+                    "been restarted, taking my turn back");
+    }
+
     @VisibleForTesting
     public static RepairTurn myTurnToRunRepair(RepairType repairType, UUID myId)
     {
@@ -493,7 +775,7 @@ public class AutoRepairUtils
             List<AutoRepairHistory> autoRepairHistories = getAutoRepairHistory(repairType);
             Set<UUID> autoRepairHistoryIds = new HashSet<>();
 
-            // 1. Remove any node that is not part of group based on goissip info
+            // 1. Remove any node that is not part of group based on gossip info
             if (autoRepairHistories != null)
             {
                 for (AutoRepairHistory nodeHistory : autoRepairHistories)
@@ -501,7 +783,7 @@ public class AutoRepairUtils
                     autoRepairHistoryIds.add(nodeHistory.hostId);
                     // clear delete_hosts if the node's delete hosts is not growing for more than two hours
                     AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
-                    if (nodeHistory.deleteHosts.size() > 0
+                    if (!nodeHistory.deleteHosts.isEmpty()
                         && config.getAutoRepairHistoryClearDeleteHostsBufferInterval().toSeconds() < TimeUnit.MILLISECONDS.toSeconds(
                     currentTimeMillis() - nodeHistory.deleteHostsUpdateTime
                     ))
@@ -538,11 +820,14 @@ public class AutoRepairUtils
                 }
             }
 
-            //get current repair status
-            CurrentRepairStatus currentRepairStatus = getCurrentRepairStatus(repairType, autoRepairHistories);
+            // get updated current repair status
+            CurrentRepairStatus currentRepairStatus = getCurrentRepairStatus(repairType, getAutoRepairHistory(repairType), myId);
             if (currentRepairStatus != null)
             {
-                logger.info("Latest repair status {}", currentRepairStatus);
+                if (logger.isDebugEnabled())
+                {
+                    logger.debug("Latest repair status {}", currentRepairStatus);
+                }
                 //check if I am forced to run repair
                 for (AutoRepairHistory history : currentRepairStatus.historiesWithoutOnGoingRepair)
                 {
@@ -550,6 +835,23 @@ public class AutoRepairUtils
                     {
                         return MY_TURN_FORCE_REPAIR;
                     }
+                }
+            }
+
+            // check if node was already indicated as having an ongoing repair, this may happen when a node restarts
+            // before finishing repairing.
+            if (currentRepairStatus != null && currentRepairStatus.getAllHostsWithOngoingRepair().contains(myId))
+            {
+                logAlreadyMyTurn();
+
+                // use the previously chosen turn.
+                if (currentRepairStatus.myRepairHistory != null && currentRepairStatus.myRepairHistory.repairTurn != null)
+                {
+                    return RepairTurn.valueOf(currentRepairStatus.myRepairHistory.repairTurn);
+                }
+                else
+                {
+                    return MY_TURN;
                 }
             }
 
@@ -567,16 +869,17 @@ public class AutoRepairUtils
                 {
                     // try to fetch again
                     autoRepairHistories = getAutoRepairHistory(repairType);
-                    currentRepairStatus = getCurrentRepairStatus(repairType, autoRepairHistories);
-                    if (autoRepairHistories == null || currentRepairStatus == null)
+                    if (autoRepairHistories == null)
                     {
                         logger.error("No record found");
                         return NOT_MY_TURN;
                     }
+
+                    currentRepairStatus = getCurrentRepairStatus(repairType, autoRepairHistories, myId);
                 }
 
                 UUID priorityHostId = null;
-                if (currentRepairStatus != null && currentRepairStatus.priority != null)
+                if (currentRepairStatus.priority != null)
                 {
                     for (UUID priorityID : currentRepairStatus.priority)
                     {
@@ -597,21 +900,37 @@ public class AutoRepairUtils
                 if (priorityHostId != null && !myId.equals(priorityHostId))
                 {
                     logger.info("Priority list is not empty and I'm not the first node in the list, not my turn." +
-                                "First node in priority list is {}", ClusterMetadata.current().directory.addresses.get(NodeId.fromUUID(priorityHostId)));
+                                "First node in priority list is {}", getBroadcastAddress(priorityHostId));
                     return NOT_MY_TURN;
                 }
+
                 if (myId.equals(priorityHostId))
                 {
                     //I have a priority for repair hence its my turn now
                     return MY_TURN_DUE_TO_PRIORITY;
                 }
-                // get the longest unrepaired node from the nodes which are not running repair
-                AutoRepairHistory defaultNodeToBeRepaired = getHostWithLongestUnrepairTime(currentRepairStatus.historiesWithoutOnGoingRepair);
-                //check who is next, which is helpful for debugging
-                logger.info("Next node to be repaired for repair type {} by default: {}", repairType, defaultNodeToBeRepaired);
-                if (defaultNodeToBeRepaired != null && defaultNodeToBeRepaired.hostId.equals(myId))
+
+                // Determine if this node is the most eligible host to repair.
+                AutoRepairHistory nodeToBeRepaired = getMostEligibleHostToRepair(repairType, currentRepairStatus, myId);
+                if (nodeToBeRepaired != null)
                 {
-                    return MY_TURN;
+                    if (nodeToBeRepaired.hostId.equals(myId))
+                    {
+                        logger.info("This node is selected to be repaired for repair type {}", repairType);
+                        return MY_TURN;
+                    }
+
+                    // log which node is next, which is helpful for debugging
+                    logger.info("Next node to be repaired for repair type {}: {} ({})", repairType,
+                                 getBroadcastAddress(nodeToBeRepaired.hostId),
+                                 nodeToBeRepaired);
+                }
+
+                // If this node is not identified as most eligible, set the repair lag time.
+                if (currentRepairStatus.myRepairHistory != null)
+                {
+                    AutoRepairMetricsManager.getMetrics(repairType)
+                                            .recordRepairStartLag(currentRepairStatus.myRepairHistory.lastRepairFinishTime);
                 }
             }
             else if (currentRepairStatus.hostIdsWithOnGoingForceRepair.contains(myId))
@@ -656,7 +975,6 @@ public class AutoRepairUtils
                                                                                                     ByteBufferUtil.bytes(repairType.toString()),
                                                                                                     ByteBufferUtil.bytes(myId)
                                                                                  )), Dispatcher.RequestTime.forImmediateExecution());
-        // Do not remove beblow log, the log is used by dtest
         logger.info("Auto repair finished for {}", myId);
     }
 
@@ -756,7 +1074,7 @@ public class AutoRepairUtils
         repairPriorityResult = UntypedResultSet.create(repairPriorityRows.result);
 
         Set<UUID> priorities = null;
-        if (repairPriorityResult.size() > 0)
+        if (!repairPriorityResult.isEmpty())
         {
             // there should be only one row
             UntypedResultSet.Row row = repairPriorityResult.one();
@@ -774,7 +1092,13 @@ public class AutoRepairUtils
         Set<InetAddressAndPort> hosts = new HashSet<>();
         for (UUID hostId : getPriorityHostIds(repairType))
         {
-            hosts.add(ClusterMetadata.current().directory.addresses.get(NodeId.fromUUID(hostId)).broadcastAddress);
+            InetAddressAndPort broadcastAddress = getBroadcastAddress(hostId);
+            if (broadcastAddress == null)
+            {
+                logger.warn("Could not resolve broadcastAddress for {}, skipping considering it as a priority host", hostId);
+                continue;
+            }
+            hosts.add(broadcastAddress);
         }
         return hosts;
     }

--- a/src/java/org/apache/cassandra/service/AutoRepairService.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairService.java
@@ -203,6 +203,18 @@ public class AutoRepairService implements AutoRepairServiceMBean
     }
 
     @Override
+    public void setAllowParallelReplicaRepair(String repairType, boolean enabled)
+    {
+        config.setAllowParallelReplicaRepair(RepairType.parse(repairType), enabled);
+    }
+
+    @Override
+    public void setAllowParallelReplicaRepairAcrossSchedules(String repairType, boolean enabled)
+    {
+        config.setAllowParallelReplicaRepairAcrossSchedules(RepairType.parse(repairType), enabled);
+    }
+
+    @Override
     public void setMVRepairEnabled(String repairType, boolean enabled)
     {
         config.setMaterializedViewRepairEnabled(RepairType.parse(repairType), enabled);
@@ -223,7 +235,7 @@ public class AutoRepairService implements AutoRepairServiceMBean
             return Collections.emptySet();
         }
         Set<String> hostIds = new HashSet<>();
-        AutoRepairUtils.CurrentRepairStatus currentRepairStatus = new AutoRepairUtils.CurrentRepairStatus(histories, AutoRepairUtils.getPriorityHostIds(RepairType.parse(repairType)));
+        AutoRepairUtils.CurrentRepairStatus currentRepairStatus = new AutoRepairUtils.CurrentRepairStatus(histories, AutoRepairUtils.getPriorityHostIds(RepairType.parse(repairType)), null);
         for (UUID id : currentRepairStatus.hostIdsWithOnGoingRepair)
         {
             hostIds.add(id.toString());
@@ -273,21 +285,23 @@ public class AutoRepairService implements AutoRepairServiceMBean
                 appendConfig(sb, "priority_hosts", Joiner.on(',').skipNulls().join(priorityHosts));
             }
 
-            appendConfig(sb , "min_repair_interval", config.getRepairMinInterval(repairType));
-            appendConfig(sb , "repair_by_keyspace", config.getRepairByKeyspace(repairType));
-            appendConfig(sb , "number_of_repair_threads", config.getRepairThreads(repairType));
-            appendConfig(sb , "sstable_upper_threshold", config.getRepairSSTableCountHigherThreshold(repairType));
-            appendConfig(sb , "table_max_repair_time", config.getAutoRepairTableMaxRepairTime(repairType));
-            appendConfig(sb , "ignore_dcs", config.getIgnoreDCs(repairType));
-            appendConfig(sb , "repair_primary_token_range_only", config.getRepairPrimaryTokenRangeOnly(repairType));
-            appendConfig(sb , "parallel_repair_count", config.getParallelRepairCount(repairType));
-            appendConfig(sb , "parallel_repair_percentage", config.getParallelRepairPercentage(repairType));
-            appendConfig(sb , "materialized_view_repair_enabled", config.getMaterializedViewRepairEnabled(repairType));
-            appendConfig(sb , "initial_scheduler_delay", config.getInitialSchedulerDelay(repairType));
-            appendConfig(sb , "repair_session_timeout", config.getRepairSessionTimeout(repairType));
-            appendConfig(sb , "force_repair_new_node", config.getForceRepairNewNode(repairType));
-            appendConfig(sb , "repair_max_retries", config.getRepairMaxRetries(repairType));
-            appendConfig(sb , "repair_retry_backoff", config.getRepairRetryBackoff(repairType));
+            appendConfig(sb, "min_repair_interval", config.getRepairMinInterval(repairType));
+            appendConfig(sb, "repair_by_keyspace", config.getRepairByKeyspace(repairType));
+            appendConfig(sb, "number_of_repair_threads", config.getRepairThreads(repairType));
+            appendConfig(sb, "sstable_upper_threshold", config.getRepairSSTableCountHigherThreshold(repairType));
+            appendConfig(sb, "table_max_repair_time", config.getAutoRepairTableMaxRepairTime(repairType));
+            appendConfig(sb, "ignore_dcs", config.getIgnoreDCs(repairType));
+            appendConfig(sb, "repair_primary_token_range_only", config.getRepairPrimaryTokenRangeOnly(repairType));
+            appendConfig(sb, "parallel_repair_count", config.getParallelRepairCount(repairType));
+            appendConfig(sb, "parallel_repair_percentage", config.getParallelRepairPercentage(repairType));
+            appendConfig(sb, "allow_parallel_replica_repair", config.getAllowParallelReplicaRepair(repairType));
+            appendConfig(sb, "allow_parallel_replica_repair_across_schedules", config.getAllowParallelReplicaRepairAcrossSchedules(repairType));
+            appendConfig(sb, "materialized_view_repair_enabled", config.getMaterializedViewRepairEnabled(repairType));
+            appendConfig(sb, "initial_scheduler_delay", config.getInitialSchedulerDelay(repairType));
+            appendConfig(sb, "repair_session_timeout", config.getRepairSessionTimeout(repairType));
+            appendConfig(sb, "force_repair_new_node", config.getForceRepairNewNode(repairType));
+            appendConfig(sb, "repair_max_retries", config.getRepairMaxRetries(repairType));
+            appendConfig(sb, "repair_retry_backoff", config.getRepairRetryBackoff(repairType));
 
             final ParameterizedClass splitterClass = config.getTokenRangeSplitter(repairType);
             final String splitterClassName =  splitterClass.class_name != null ? splitterClass.class_name : AutoRepairConfig.DEFAULT_SPLITTER.getName();

--- a/src/java/org/apache/cassandra/service/AutoRepairServiceMBean.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairServiceMBean.java
@@ -53,6 +53,10 @@ public interface AutoRepairServiceMBean
 
     public void setParallelRepairCount(String repairType, int count);
 
+    public void setAllowParallelReplicaRepair(String repairType, boolean enabled);
+
+    public void setAllowParallelReplicaRepairAcrossSchedules(String repairType, boolean enabled);
+
     public void setMVRepairEnabled(String repairType, boolean enabled);
 
     public boolean isAutoRepairDisabled();

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -374,8 +374,12 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
 
     public RangesAtEndpoint getReplicas(String keyspaceName, InetAddressAndPort endpoint)
     {
-        return Keyspace.open(keyspaceName).getReplicationStrategy()
-                       .getAddressReplicas(ClusterMetadata.current(), endpoint);
+        return getReplicas(Keyspace.open(keyspaceName).getReplicationStrategy(), endpoint);
+    }
+
+    public RangesAtEndpoint getReplicas(AbstractReplicationStrategy replicationStrategy, InetAddressAndPort endpoint)
+    {
+        return replicationStrategy.getAddressReplicas(ClusterMetadata.current(), endpoint);
     }
 
     public List<Range<Token>> getLocalRanges(String ks)

--- a/src/java/org/apache/cassandra/tools/NodeProbe.java
+++ b/src/java/org/apache/cassandra/tools/NodeProbe.java
@@ -2603,6 +2603,16 @@ public class NodeProbe implements AutoCloseable
         autoRepairProxy.setParallelRepairCount(repairType, count);
     }
 
+    public void setAutoRepairAllowParallelReplicaRepair(String repairType, boolean enabled)
+    {
+        autoRepairProxy.setAllowParallelReplicaRepair(repairType, enabled);
+    }
+
+    public void setAutoRepairAllowParallelReplicaRepairAcrossSchedules(String repairType, boolean enabled)
+    {
+        autoRepairProxy.setAllowParallelReplicaRepairAcrossSchedules(repairType, enabled);
+    }
+
     public void setAutoRepairPrimaryTokenRangeOnly(String repairType, boolean primaryTokenRangeOnly)
     {
         autoRepairProxy.setPrimaryTokenRangeOnly(repairType, primaryTokenRangeOnly);

--- a/src/java/org/apache/cassandra/tools/nodetool/SetAutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/tools/nodetool/SetAutoRepairConfig.java
@@ -47,7 +47,9 @@ public class SetAutoRepairConfig extends NodeToolCmd
                   "[start_scheduler|number_of_repair_threads|min_repair_interval|sstable_upper_threshold" +
                   "|enabled|table_max_repair_time|priority_hosts|forcerepair_hosts|ignore_dcs" +
                   "|history_clear_delete_hosts_buffer_interval|repair_primary_token_range_only" +
-                  "|parallel_repair_count|parallel_repair_percentage|materialized_view_repair_enabled|repair_max_retries" +
+                  "|parallel_repair_count|parallel_repair_percentage" +
+                  "|allow_parallel_replica_repair|allow_parallel_repair_across_schedules" +
+                  "|materialized_view_repair_enabled|repair_max_retries" +
                   "|repair_retry_backoff|repair_session_timeout|min_repair_task_duration" +
                   "|repair_by_keyspace|token_range_splitter.<property>]",
     required = true)
@@ -147,6 +149,12 @@ public class SetAutoRepairConfig extends NodeToolCmd
                 break;
             case "parallel_repair_percentage":
                 probe.setAutoRepairParallelRepairPercentage(repairTypeStr, Integer.parseInt(paramVal));
+                break;
+            case "allow_parallel_replica_repair":
+                probe.setAutoRepairAllowParallelReplicaRepair(repairTypeStr, Boolean.parseBoolean(paramVal));
+                break;
+            case "allow_parallel_replica_repair_across_schedules":
+                probe.setAutoRepairAllowParallelReplicaRepairAcrossSchedules(repairTypeStr, Boolean.parseBoolean(paramVal));
                 break;
             case "materialized_view_repair_enabled":
                 probe.setAutoRepairMaterializedViewRepairEnabled(repairTypeStr, Boolean.parseBoolean(paramVal));

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerDisallowParallelReplicaRepairAcrossSchedulesTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerDisallowParallelReplicaRepairAcrossSchedulesTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.distributed.test.repair;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.ImmutableMap;
+
+import org.apache.cassandra.Util;
+import org.apache.cassandra.metrics.AutoRepairMetrics;
+import org.apache.cassandra.metrics.AutoRepairMetricsManager;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.distributed.Cluster;
+import org.apache.cassandra.distributed.test.TestBaseImpl;
+import org.apache.cassandra.repair.autorepair.AutoRepair;
+import org.apache.cassandra.repair.autorepair.AutoRepairConfig;
+import org.apache.cassandra.service.AutoRepairService;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Distributed tests for {@link org.apache.cassandra.repair.autorepair.AutoRepair} scheduler's
+ * allow_parallel_replica_repair_across_schedules feature.
+ */
+public class AutoRepairSchedulerDisallowParallelReplicaRepairAcrossSchedulesTest extends TestBaseImpl
+{
+    private static Cluster cluster;
+
+    @BeforeClass
+    public static void init() throws IOException
+    {
+        // Configure a cluster with preview and incremental repair enabled in a way that preview repair can be
+        // run on all three nodes concurrently, but incremental repair can only be run when there are no parallel
+        // repairs.  We should detect contention in the incremental repair scheduler but not preview repaired
+        // scheduler as a result.
+        cluster = Cluster.build(3)
+                         .withConfig(config -> config
+                                               .set("auto_repair",
+                                                    ImmutableMap.of(
+                                                    "repair_type_overrides",
+                                                    ImmutableMap.of(AutoRepairConfig.RepairType.PREVIEW_REPAIRED.getConfigName(),
+                                                                    ImmutableMap.of(
+                                                                    // Configure preview repair to run frequently to
+                                                                    // provoke contention with incremental scheduler.
+                                                                    "initial_scheduler_delay", "5s",
+                                                                    "enabled", "true",
+                                                                    "parallel_repair_count", "3",
+                                                                    "allow_parallel_replica_repair", "true",
+                                                                    "min_repair_interval", "5s"),
+                                                                    AutoRepairConfig.RepairType.INCREMENTAL.getConfigName(),
+                                                                    ImmutableMap.of(
+                                                                    "initial_scheduler_delay", "5s",
+                                                                    "enabled", "true",
+                                                                    "parallel_repair_count", "3",
+                                                                    // Don't allow parallel replica repair across
+                                                                    // schedules
+                                                                    "allow_parallel_replica_repair", "false",
+                                                                    "allow_parallel_replica_repair_across_schedules", "false",
+                                                                    "min_repair_interval", "5s"))))
+                                               .set("auto_repair.enabled", "true")
+                                               .set("auto_repair.global_settings.repair_retry_backoff", "5s")
+                                               .set("auto_repair.repair_task_min_duration", "0s")
+                                               .set("auto_repair.repair_check_interval", "5s"))
+                         .start();
+
+        cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};");
+        cluster.schemaChange(withKeyspace("CREATE TABLE %s.tbl (pk int, ck text, v1 int, v2 int, PRIMARY KEY (pk, ck)) WITH read_repair='NONE'"));
+    }
+
+    @AfterClass
+    public static void tearDown()
+    {
+        cluster.close();
+    }
+
+    @Test
+    public void testScheduler()
+    {
+        cluster.forEach(i -> i.runOnInstance(() -> {
+            try
+            {
+                AutoRepairService.setup();
+                AutoRepair.instance.setup();
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException(e);
+            }
+        }));
+
+        // validate that the repair ran on all nodes
+        cluster.forEach(i -> i.runOnInstance(() -> {
+            // Expect contention on incremental repair across schedules
+            AutoRepairMetrics incrementalMetrics = AutoRepairMetricsManager.getMetrics(AutoRepairConfig.RepairType.INCREMENTAL);
+            Util.spinAssert("AutoRepair has not observed any replica contention in INCREMENTAL repair",
+                            greaterThan(0L),
+                            incrementalMetrics.repairDelayedBySchedule::getCount,
+                            5,
+                            TimeUnit.MINUTES);
+
+            // No repair contention should be observed for preview repaired since allow_parallel_replica_repair was true
+            AutoRepairMetrics previewMetrics = AutoRepairMetricsManager.getMetrics(AutoRepairConfig.RepairType.PREVIEW_REPAIRED);
+            assertEquals(0L, previewMetrics.repairDelayedByReplica.getCount());
+            assertEquals(0L, previewMetrics.repairDelayedBySchedule.getCount());
+        }));
+    }
+}

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
@@ -27,9 +27,13 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.collect.ImmutableMap;
 
 import org.apache.cassandra.Util;
-import org.apache.cassandra.config.DatabaseDescriptor;
+import org.apache.cassandra.config.DurationSpec;
+import org.apache.cassandra.distributed.api.TokenSupplier;
+import org.apache.cassandra.metrics.AutoRepairMetrics;
+import org.apache.cassandra.metrics.AutoRepairMetricsManager;
 import org.apache.cassandra.schema.SystemDistributedKeyspace;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -46,7 +50,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Unit tests for {@link org.apache.cassandra.repair.autorepair.AutoRepair}
+ * Distributed tests for {@link org.apache.cassandra.repair.autorepair.AutoRepair} scheduler
  */
 public class AutoRepairSchedulerTest extends TestBaseImpl
 {
@@ -61,31 +65,55 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
         // Create SimpleDateFormat object with the given pattern
         sdf = new SimpleDateFormat(pattern);
         sdf.setLenient(false);
-        cluster = Cluster.build(3).withConfig(config -> config
-                                                        .set("auto_repair",
-                                                             ImmutableMap.of(
-                                                             "repair_type_overrides",
-                                                             ImmutableMap.of(AutoRepairConfig.RepairType.FULL.getConfigName(),
-                                                                             ImmutableMap.of(
-                                                                             "initial_scheduler_delay", "5s",
-                                                                             "enabled", "true",
-                                                                             "parallel_repair_count", "1",
-                                                                             "parallel_repair_percentage", "0",
-                                                                             "min_repair_interval", "1s"),
-                                                                             AutoRepairConfig.RepairType.INCREMENTAL.getConfigName(),
-                                                                             ImmutableMap.of(
-                                                                             "initial_scheduler_delay", "5s",
-                                                                             "enabled", "true",
-                                                                             "parallel_repair_count", "1",
-                                                                             "parallel_repair_percentage", "0",
-                                                                             "min_repair_interval", "1s"))))
-                                                        .set("auto_repair.enabled", "true")
-                                                        .set("auto_repair.global_settings.repair_by_keyspace", "true")
-                                                        .set("auto_repair.repair_task_min_duration", "0s")
-                                                        .set("auto_repair.repair_check_interval", "10s")).start();
+        // Configure a 3-node cluster with num_tokens: 4 and auto_repair enabled
+        cluster = Cluster.build(3)
+                         .withTokenCount(4)
+                         .withTokenSupplier(TokenSupplier.evenlyDistributedTokens(3, 4))
+                         .withConfig(config -> config
+                                               .set("num_tokens", 4)
+                                               .set("auto_repair",
+                                                    ImmutableMap.of(
+                                                    "repair_type_overrides",
+                                                    ImmutableMap.of(AutoRepairConfig.RepairType.FULL.getConfigName(),
+                                                                    ImmutableMap.of(
+                                                                    "initial_scheduler_delay", "5s",
+                                                                    "enabled", "true",
+                                                                    "parallel_repair_count", "2",
+                                                                    // Allow parallel replica repair to allow replicas
+                                                                    // to execute full repair at same time.
+                                                                    "allow_parallel_replica_repair", "true",
+                                                                    "min_repair_interval", "15s"),
+                                                                    AutoRepairConfig.RepairType.INCREMENTAL.getConfigName(),
+                                                                    ImmutableMap.of(
+                                                                    "initial_scheduler_delay", "5s",
+                                                                    "enabled", "true",
+                                                                    // Set parallel repair count to 3 to provoke
+                                                                    // contention between replicas when scheduling.
+                                                                    "parallel_repair_count", "3",
+                                                                    // Disallow parallel replica repair to prevent
+                                                                    // replicas from issuing incremental repair at
+                                                                    // same time.
+                                                                    "allow_parallel_replica_repair", "false",
+                                                                    // Run more aggressively since full repair is
+                                                                    // less restrictive about when it can run repair,
+                                                                    // so need to check more frequently to allow
+                                                                    // incremental to get an attempt in.
+                                                                    "min_repair_interval", "5s"))))
+                                               .set("auto_repair.enabled", "true")
+                                               .set("auto_repair.global_settings.repair_by_keyspace", "true")
+                                               .set("auto_repair.global_settings.repair_retry_backoff", "5s")
+                                               .set("auto_repair.repair_task_min_duration", "0s")
+                                               .set("auto_repair.repair_check_interval", "5s"))
+                         .start();
 
         cluster.schemaChange("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3};");
         cluster.schemaChange(withKeyspace("CREATE TABLE %s.tbl (pk int, ck text, v1 int, v2 int, PRIMARY KEY (pk, ck)) WITH read_repair='NONE'"));
+    }
+
+    @AfterClass
+    public static void tearDown()
+    {
+        cluster.close();
     }
 
     @Test
@@ -98,10 +126,7 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
         cluster.forEach(i -> i.runOnInstance(() -> {
             try
             {
-                DatabaseDescriptor.setCDCOnRepairEnabled(false);
-                DatabaseDescriptor.setMaterializedViewsOnRepairEnabled(false);
-                AutoRepairService.instance.setup();
-                DatabaseDescriptor.setCDCOnRepairEnabled(false);
+                AutoRepairService.setup();
                 AutoRepair.instance.setup();
             }
             catch (Exception e)
@@ -112,17 +137,39 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
 
         // validate that the repair ran on all nodes
         cluster.forEach(i -> i.runOnInstance(() -> {
-            Util.spinAssert("AutoRepair has not yet completed one FULL repair cycle",
-                            greaterThan(0L),
-                            AutoRepair.instance.repairStates.get(AutoRepairConfig.RepairType.FULL)::getLastRepairTime,
-                            5,
-                            TimeUnit.MINUTES);
+            // Reduce sleeping if repair finishes quickly to speed up test but make it non-zero to provoke some
+            // contention.
+            AutoRepair.SLEEP_IF_REPAIR_FINISHES_QUICKLY = new DurationSpec.IntSecondsBound("1s");
+
+            AutoRepairMetrics incrementalMetrics = AutoRepairMetricsManager.getMetrics(AutoRepairConfig.RepairType.INCREMENTAL);
             Util.spinAssert("AutoRepair has not yet completed one INCREMENTAL repair cycle",
                             greaterThan(0L),
-                            AutoRepair.instance.repairStates.get(AutoRepairConfig.RepairType.INCREMENTAL)::getLastRepairTime,
+                            () -> incrementalMetrics.nodeRepairTimeInSec.getValue().longValue(),
                             5,
                             TimeUnit.MINUTES);
+
+            // Expect some contention on incremental repair.
+            Util.spinAssert("AutoRepair has not observed any replica contention in INCREMENTAL repair",
+                            greaterThan(0L),
+                            incrementalMetrics.repairDelayedByReplica::getCount,
+                            5,
+                            TimeUnit.MINUTES);
+            // Do not expect any contention across schedules since allow_parallel_replica_repairs across schedules
+            // was not configured.
+            assertEquals(0L, incrementalMetrics.repairDelayedBySchedule.getCount());
+
+            AutoRepairMetrics fullMetrics = AutoRepairMetricsManager.getMetrics(AutoRepairConfig.RepairType.FULL);
+            Util.spinAssert("AutoRepair has not yet completed one FULL repair cycle",
+                            greaterThan(0L),
+                            () -> fullMetrics.nodeRepairTimeInSec.getValue().longValue(),
+                            5,
+                            TimeUnit.MINUTES);
+
+            // No repair contention should be observed for full repair since allow_parallel_replica_repair was true
+            assertEquals(0L, fullMetrics.repairDelayedByReplica.getCount());
+            assertEquals(0L, fullMetrics.repairDelayedBySchedule.getCount());
         }));
+
         validate(AutoRepairConfig.RepairType.FULL.toString());
         validate(AutoRepairConfig.RepairType.INCREMENTAL.toString());
     }
@@ -137,7 +184,7 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
             // repair_type
             Assert.assertEquals(repairType, row[0].toString());
             // host_id
-            UUID.fromString(row[1].toString());
+            Assert.assertNotNull(UUID.fromString(row[1].toString()));
             // ensure there is a legit repair_start_ts and repair_finish_ts
             sdf.parse(row[2].toString());
             sdf.parse(row[3].toString());

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
@@ -20,7 +20,6 @@ package org.apache.cassandra.repair.autorepair;
 
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Collections;
 import java.util.Set;
 
@@ -155,7 +154,7 @@ public class AutoRepairConfigTest extends CQLTester
     {
         config.setRepairThreads(repairType, 5);
 
-        assert config.getOptions(repairType).number_of_repair_threads == 5;
+        assertEquals(5, config.getOptions(repairType).number_of_repair_threads.intValue());
     }
 
     @Test
@@ -183,7 +182,7 @@ public class AutoRepairConfigTest extends CQLTester
     {
         config.setRepairMinInterval(repairType, "5s");
 
-        assert config.getOptions(repairType).min_repair_interval.toSeconds() == 5;
+        assertEquals(5, config.getOptions(repairType).min_repair_interval.toSeconds());
     }
 
     @Test
@@ -201,7 +200,7 @@ public class AutoRepairConfigTest extends CQLTester
     {
         config.setAutoRepairHistoryClearDeleteHostsBufferInterval("5s");
 
-        assert Objects.equals(config.history_clear_delete_hosts_buffer_interval, new DurationSpec.IntSecondsBound("5s"));
+        assertEquals(new DurationSpec.IntSecondsBound("5s"), config.history_clear_delete_hosts_buffer_interval);
     }
 
     @Test
@@ -219,7 +218,7 @@ public class AutoRepairConfigTest extends CQLTester
     {
         config.setRepairSSTableCountHigherThreshold(repairType, 5);
 
-        assert config.getOptions(repairType).sstable_upper_threshold == 5;
+        assertEquals(5, config.getOptions(repairType).sstable_upper_threshold.intValue());
     }
 
     @Test
@@ -237,8 +236,8 @@ public class AutoRepairConfigTest extends CQLTester
     {
         config.setAutoRepairTableMaxRepairTime(repairType, "5s");
 
-        assert config.getOptions(repairType).table_max_repair_time.toSeconds() == 5;
-    }
+    assertEquals(5, config.getOptions(repairType).table_max_repair_time.toSeconds());
+}
 
     @Test
     public void testGetIgnoreDCs()
@@ -291,7 +290,7 @@ public class AutoRepairConfigTest extends CQLTester
     {
         config.setParallelRepairPercentage(repairType, 5);
 
-        assert config.getOptions(repairType).parallel_repair_percentage == 5;
+        assertEquals(5, config.getOptions(repairType).parallel_repair_percentage.intValue());
     }
 
     @Test
@@ -309,7 +308,55 @@ public class AutoRepairConfigTest extends CQLTester
     {
         config.setParallelRepairCount(repairType, 5);
 
-        assert config.getOptions(repairType).parallel_repair_count == 5;
+        assertEquals(5, config.getOptions(repairType).parallel_repair_count.intValue());
+    }
+
+    @Test
+    public void testGetAllowParallelReplicaRepair()
+    {
+        // should default to false
+        assertFalse(config.global_settings.allow_parallel_replica_repair);
+        assertFalse(config.getAllowParallelReplicaRepair(repairType));
+
+        // setting global to true should also cause repair type config to inherit.
+        config.global_settings.allow_parallel_replica_repair = true;
+        assertTrue(config.getAllowParallelReplicaRepair(repairType));
+
+    }
+
+    @Test
+    public void testSetAllowParallelReplicaRepair()
+    {
+        // should default to false
+        assertFalse(config.getAllowParallelReplicaRepair(repairType));
+
+        // setting explicitly for repair type should update it
+        config.setAllowParallelReplicaRepair(repairType, true);
+        assertTrue(config.getAllowParallelReplicaRepair(repairType));
+    }
+
+    @Test
+    public void testGetAllowParallelReplicaRepairAcrossSchedules()
+    {
+        // should default to true
+        assertTrue(config.global_settings.allow_parallel_replica_repair_across_schedules);
+        assertTrue(config.getAllowParallelReplicaRepairAcrossSchedules(repairType));
+
+        // setting global to true should also cause repair type config to inherit.
+        config.global_settings.allow_parallel_replica_repair_across_schedules = false;
+        assertFalse(config.getAllowParallelReplicaRepairAcrossSchedules(repairType));
+
+    }
+
+    @Test
+    public void testSetAllowParallelReplicaRepairAcrossSchedules()
+    {
+        // should default to true
+        assertTrue(config.getAllowParallelReplicaRepairAcrossSchedules(repairType));
+
+        // setting explicitly for repair type should update it
+        config.setAllowParallelReplicaRepairAcrossSchedules(repairType, false);
+        assertFalse(config.getAllowParallelReplicaRepairAcrossSchedules(repairType));
     }
 
     @Test
@@ -396,7 +443,7 @@ public class AutoRepairConfigTest extends CQLTester
     {
         config.setInitialSchedulerDelay(repairType, "5s");
 
-        assert config.getOptions(repairType).initial_scheduler_delay.toSeconds() == 5;
+        assertEquals(5, config.getOptions(repairType).initial_scheduler_delay.toSeconds());
     }
 
     @Test
@@ -414,7 +461,7 @@ public class AutoRepairConfigTest extends CQLTester
     {
         config.setRepairSessionTimeout(repairType, "1h");
 
-        assert config.getOptions(repairType).repair_session_timeout.toSeconds() == 3600;
+        assertEquals(3600, config.getOptions(repairType).repair_session_timeout.toSeconds());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairMetricsTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairMetricsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.cassandra.repair.autorepair;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.metrics.AutoRepairMetrics;
+import org.apache.cassandra.metrics.AutoRepairMetricsManager;
+import org.apache.cassandra.repair.autorepair.AutoRepairConfig.RepairType;
+import org.apache.cassandra.repair.autorepair.AutoRepairUtils.RepairTurn;
+import org.apache.cassandra.service.AutoRepairService;
+import org.apache.cassandra.service.StorageService;
+
+import static org.apache.cassandra.Util.setAutoRepairEnabled;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AutoRepairMetricsTest extends CQLTester
+{
+
+    private AutoRepairMetrics metrics;
+
+    @BeforeClass
+    public static void setupClass() throws Exception
+    {
+        setAutoRepairEnabled(true);
+        requireNetwork();
+        AutoRepairUtils.setup();
+        StorageService.instance.doAutoRepairSetup();
+
+        // Set min repair interval to an hour.
+        AutoRepairConfig config = AutoRepairService.instance.getAutoRepairConfig();
+        config.setRepairMinInterval(RepairType.FULL, "1h");
+    }
+
+    @Before
+    public void setup()
+    {
+        metrics = AutoRepairMetricsManager.getMetrics(RepairType.FULL);
+    }
+
+    @Test
+    public void testShouldRecordRepairStartLagAndResetOnMyTurn()
+    {
+        // record a last finish repair time of one day.
+        long oneDayAgo = AutoRepair.instance.currentTimeMs() - 86_400_000;
+        metrics.recordRepairStartLag(oneDayAgo);
+
+        // expect a recorded lag time of approximately 1 day (last repair finish time) - 1 hour (min repair interval)
+        long expectedLag = 86400 - 3600;
+        long recordedLag = metrics.repairStartLagSec.getValue();
+        assertTrue(String.format("Expected at last 23h of lag (%d) but got (%d)", expectedLag, recordedLag),
+                   recordedLag >= expectedLag);
+        // Given timing, allow at most 5 seconds of skew.
+        assertTrue(String.format("Expected 23h of lag (%d) but got a larger value (%d)", expectedLag, recordedLag),
+                   recordedLag <= expectedLag + 5);
+
+        // expect lag time to be restarted when recording a turn.
+        metrics.recordTurn(RepairTurn.MY_TURN);
+        assertEquals(0, metrics.repairStartLagSec.getValue().intValue());
+    }
+
+    @Test
+    public void testShouldRecordRepairStartLagOfZeroWhenFinishTimeIsWithinMinRepairInterval()
+    {
+        // record a last finish repair time of one 30 minutes
+        long thirtyMinutesAgo = AutoRepair.instance.currentTimeMs() - 1_800_000;
+        metrics.recordRepairStartLag(thirtyMinutesAgo);
+
+        // expect 0 lag because last repair finish time was less than min repair interval
+        assertEquals(0, metrics.repairStartLagSec.getValue().intValue());
+    }
+}

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -275,6 +275,8 @@ public class AutoRepairParameterizedTest extends CQLTester
         //if repair was done then lastRepairTime should be non-zero
         Assert.assertTrue(String.format("Expected lastRepairTime > 0, actual value lastRepairTime %d",
                                         lastRepairTime), lastRepairTime > 0);
+        // repair start lag sec should be reset  on a successful repair
+        assertEquals(0, AutoRepairMetricsManager.getMetrics(repairType).repairStartLagSec.getValue().intValue());
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairUtilsTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairUtilsTest.java
@@ -194,7 +194,7 @@ public class AutoRepairUtilsTest extends CQLTester
         SchemaConstants.DISTRIBUTED_KEYSPACE_NAME, SystemDistributedKeyspace.AUTO_REPAIR_PRIORITY,
         repairType.toString(), regularRepair));
 
-        CurrentRepairStatus status = AutoRepairUtils.getCurrentRepairStatus(repairType);
+        CurrentRepairStatus status = AutoRepairUtils.getCurrentRepairStatus(repairType, AutoRepairUtils.getAutoRepairHistory(repairType), hostId);
 
         assertNotNull(status);
         assertEquals(1, status.historiesWithoutOnGoingRepair.size());
@@ -205,6 +205,7 @@ public class AutoRepairUtilsTest extends CQLTester
         assertTrue(status.hostIdsWithOnGoingForceRepair.contains(forceRepair));
         assertEquals(1, status.priority.size());
         assertTrue(status.priority.contains(regularRepair));
+        assertEquals(hostId, status.myRepairHistory.hostId);
     }
 
     @Test


### PR DESCRIPTION
Previously AutoRepairUtils.myTurnToRunRepair would return MY_TURN if there is capacity to select a new node for repair and the current node has the oldest lastRepairFinishTime.

This change adjusts this method to make use of a newly added method getMostEligibleHostToRepair which will identify the node with the oldest lastRepairFinishTime of which none of the node's replicas are actively repairing.

This should prevent replicas from actively repairing concurrently, which would increase load on replica sets and also create anticompaction conflicts for incremental repair.
