### PR TITLE
Add toString() to AutoRepairConfig.java

### DIFF
--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
@@ -594,4 +594,16 @@ public class AutoRepairConfig implements Serializable
         // Otherwise check defaults
         return getOverride(Options.getDefaultOptionsMap().get(repairType), optionSupplier);
     }
+
+    public String toString()
+    {
+        return "AutoRepairConfig{" +
+               "enabled=" + enabled +
+               ", repair_check_interval=" + repair_check_interval +
+               ", history_clear_delete_hosts_buffer_interval=" + history_clear_delete_hosts_buffer_interval +
+               ", repair_task_min_duration=" + repair_task_min_duration +
+               ", global_settings=" + global_settings +
+               ", repair_type_overrides=" + repair_type_overrides +
+               "}";
+    }
 }


### PR DESCRIPTION
Problem statement: On startup the missing `toString()` on AutoRepairConfig means when it logs the configs in YamlConfigurationLoader.java it shows : auto_repair=org.apache.cassandra.repair.autorepair.AutoRepairConfig@35a9782c

This PR adds the missing `toString()`

The [Cassandra Jira](https://issues.apache.org/jira/browse/CASSANDRA-20498)

