### PR TITLE
Create AutoRepair executors only if enabled and a few other nits

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1992,7 +1992,7 @@ drop_compact_storage_enabled: false
 #     materialized_view_repair_enabled: false
 #     # Delay before starting repairs after a node restarts to avoid repairs starting immediately after a restart.
 #     initial_scheduler_delay: 5m
-#     # Timeout for resuming stuck repair sessions.
+#     # Timeout for retrying stuck repair sessions.
 #     repair_session_timeout: 3h
 #     # Force immediate repair on new nodes after they join the ring.
 #     force_repair_new_node: false

--- a/doc/modules/cassandra/managing/operating/auto_repair.adoc
+++ b/doc/modules/cassandra/managing/operating/auto_repair.adoc
@@ -205,7 +205,7 @@ node. Defaults to true and is only evaluated when allow_parallel_replica_repair 
 | materialized_view_repair_enabled | false | Repairs materialized views if true.
 | initial_scheduler_delay | 5m | Delay before starting repairs after a node restarts to avoid repairs starting
 immediately after a restart.
-| repair_session_timeout | 3h | Timeout for resuming stuck repair sessions.
+| repair_session_timeout | 3h | Timeout for retrying stuck repair sessions.
 | force_repair_new_node | false | Force immediate repair on new nodes after they join the ring.
 | sstable_upper_threshold | 10000 | Threshold to skip repairing tables with too many SSTables.
 | table_max_repair_time | 6h | Maximum time allowed for repairing one table on a given node. If exceeded, the repair

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -38,7 +38,6 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
 
 import org.apache.cassandra.config.DurationSpec;
-import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.repair.RepairRunnable;
 import org.apache.cassandra.utils.Clock;
 
@@ -84,12 +83,12 @@ public class AutoRepair
     public static DurationSpec.IntSecondsBound SLEEP_IF_REPAIR_FINISHES_QUICKLY = new DurationSpec.IntSecondsBound("5s");
 
     @VisibleForTesting
-    public final Map<AutoRepairConfig.RepairType, AutoRepairState> repairStates;
+    public Map<AutoRepairConfig.RepairType, AutoRepairState> repairStates;
 
     @VisibleForTesting
-    protected final Map<AutoRepairConfig.RepairType, ScheduledExecutorPlus> repairExecutors;
+    protected Map<AutoRepairConfig.RepairType, ScheduledExecutorPlus> repairExecutors;
 
-    protected final Map<AutoRepairConfig.RepairType, ScheduledExecutorPlus> repairRunnableExecutors;
+    protected Map<AutoRepairConfig.RepairType, ScheduledExecutorPlus> repairRunnableExecutors;
 
     @VisibleForTesting
     // Auto-repair is likely to be run on multiple nodes independently, we want to avoid running multiple repair
@@ -99,21 +98,13 @@ public class AutoRepair
     @VisibleForTesting
     protected static BiConsumer<Long, TimeUnit> sleepFunc = Uninterruptibles::sleepUninterruptibly;
 
-    private boolean isSetupDone = false;
+    @VisibleForTesting
+    public boolean isSetupDone = false;
     public static AutoRepair instance = new AutoRepair();
 
-    @VisibleForTesting
-    protected AutoRepair()
+    private AutoRepair()
     {
-        repairExecutors = new EnumMap<>(AutoRepairConfig.RepairType.class);
-        repairRunnableExecutors = new EnumMap<>(AutoRepairConfig.RepairType.class);
-        repairStates = new EnumMap<>(AutoRepairConfig.RepairType.class);
-        for (AutoRepairConfig.RepairType repairType : AutoRepairConfig.RepairType.values())
-        {
-            repairExecutors.put(repairType, executorFactory().scheduled(false, "AutoRepair-Repair-" + repairType.getConfigName(), Thread.NORM_PRIORITY));
-            repairRunnableExecutors.put(repairType, executorFactory().scheduled(false, "AutoRepair-RepairRunnable-" + repairType.getConfigName(), Thread.NORM_PRIORITY));
-            repairStates.put(repairType, AutoRepairConfig.RepairType.getAutoRepairState(repairType));
-        }
+        // Private constructor to prevent instantiation
     }
 
     public void setup()
@@ -126,6 +117,16 @@ public class AutoRepair
             {
                 return;
             }
+            repairExecutors = new EnumMap<>(AutoRepairConfig.RepairType.class);
+            repairRunnableExecutors = new EnumMap<>(AutoRepairConfig.RepairType.class);
+            repairStates = new EnumMap<>(AutoRepairConfig.RepairType.class);
+            for (AutoRepairConfig.RepairType repairType : AutoRepairConfig.RepairType.values())
+            {
+                repairExecutors.put(repairType, executorFactory().scheduled(false, "AutoRepair-Repair-" + repairType.getConfigName(), Thread.NORM_PRIORITY));
+                repairRunnableExecutors.put(repairType, executorFactory().scheduled(false, "AutoRepair-RepairRunnable-" + repairType.getConfigName(), Thread.NORM_PRIORITY));
+                repairStates.put(repairType, AutoRepairConfig.RepairType.getAutoRepairState(repairType));
+            }
+
             AutoRepairConfig config = DatabaseDescriptor.getAutoRepairConfig();
             AutoRepairUtils.setup();
 
@@ -142,16 +143,6 @@ public class AutoRepair
             }
             isSetupDone = true;
         }
-    }
-
-    // repairAsync runs a repair session of the given type asynchronously.
-    public void repairAsync(AutoRepairConfig.RepairType repairType)
-    {
-        if (!AutoRepairService.instance.getAutoRepairConfig().isAutoRepairEnabled(repairType))
-        {
-            throw new ConfigurationException("Auto-repair is disabled for repair type " + repairType);
-        }
-        repairExecutors.get(repairType).submit(() -> repair(repairType));
     }
 
     /**
@@ -554,7 +545,7 @@ public class AutoRepair
         public void progress(String tag, ProgressEvent event)
         {
             ProgressEventType type = event.getType();
-            String message = String.format("[%s] %s", format.format(Clock.Global.currentTimeMillis()), event.getMessage());
+            String message = String.format("[%s] %s", format.format(timeFunc.get()), event.getMessage());
             if (type == ProgressEventType.ERROR)
             {
                 logger.error("Repair failure for repair {}: {}", repairType.toString(), message);

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
@@ -319,16 +319,6 @@ public class AutoRepairConfig implements Serializable
         return applyOverrides(repairType, opt -> opt.token_range_splitter);
     }
 
-    /**
-     * Set a new token range splitter, this is not meant to be used other than for testing.
-     */
-    @VisibleForTesting
-    void setTokenRangeSplitter(RepairType repairType, ParameterizedClass tokenRangeSplitter)
-    {
-        getOptions(repairType).token_range_splitter = tokenRangeSplitter;
-        tokenRangeSplitters.remove(repairType);
-    }
-
     public IAutoRepairTokenRangeSplitter getTokenRangeSplitterInstance(RepairType repairType)
     {
         return tokenRangeSplitters.computeIfAbsent(repairType,
@@ -529,7 +519,7 @@ public class AutoRepairConfig implements Serializable
         public volatile ParameterizedClass token_range_splitter;
         // After a node restart, wait for this much delay before scheduler starts running repair; this is to avoid starting repair immediately after a node restart.
         public volatile DurationSpec.IntSecondsBound initial_scheduler_delay;
-        // Timeout for resuming stuck repair sessions.
+        // Timeout for retrying stuck repair sessions.
         public volatile DurationSpec.IntSecondsBound repair_session_timeout;
         // Maximum number of retries for a repair session.
         public volatile Integer repair_max_retries = 3;

--- a/src/java/org/apache/cassandra/service/AutoRepairService.java
+++ b/src/java/org/apache/cassandra/service/AutoRepairService.java
@@ -71,7 +71,7 @@ public class AutoRepairService implements AutoRepairServiceMBean
     public void checkCanRun(RepairType repairType)
     {
         if (!config.isAutoRepairSchedulingEnabled())
-            throw new ConfigurationException("Auto-repair scheduller is disabled.");
+            throw new ConfigurationException("Auto-repair scheduler is disabled.");
 
         if (repairType != RepairType.INCREMENTAL)
             return;

--- a/src/java/org/apache/cassandra/service/StorageService.java
+++ b/src/java/org/apache/cassandra/service/StorageService.java
@@ -1363,8 +1363,8 @@ public class StorageService extends NotificationBroadcasterSupport implements IE
         {
             logger.info("Enabling auto-repair scheduling");
             AutoRepair.instance.setup();
+            logger.info("AutoRepair setup complete!");
         }
-        logger.info("AutoRepair setup complete!");
     }
 
 

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairParameterizedTest.java
@@ -214,8 +214,8 @@ public class AutoRepairParameterizedTest extends CQLTester
         Keyspace.open(SchemaConstants.DISTRIBUTED_KEYSPACE_NAME).getColumnFamilyStore(SystemDistributedKeyspace.AUTO_REPAIR_PRIORITY).truncateBlocking();
         Keyspace.open(SchemaConstants.DISTRIBUTED_KEYSPACE_NAME).getColumnFamilyStore(SystemDistributedKeyspace.AUTO_REPAIR_HISTORY).truncateBlocking();
 
-
-        AutoRepair.instance = new AutoRepair();
+        AutoRepair.instance.isSetupDone = false;
+        AutoRepair.instance.setup();
         executeCQL();
 
         timeFuncCalls = 0;
@@ -268,24 +268,6 @@ public class AutoRepairParameterizedTest extends CQLTester
         Keyspace.open(SchemaConstants.DISTRIBUTED_KEYSPACE_NAME)
                 .getColumnFamilyStore(SystemDistributedKeyspace.AUTO_REPAIR_PRIORITY)
                 .forceBlockingFlush(ColumnFamilyStore.FlushReason.UNIT_TESTS);
-    }
-
-    @Test(expected = ConfigurationException.class)
-    public void testRepairAsyncWithRepairTypeDisabled()
-    {
-        AutoRepairService.instance.getAutoRepairConfig().setAutoRepairEnabled(repairType, false);
-
-        AutoRepair.instance.repairAsync(repairType);
-    }
-
-    @Test
-    public void testRepairAsync()
-    {
-        AutoRepair.instance.repairExecutors.put(repairType, mockExecutor);
-
-        AutoRepair.instance.repairAsync(repairType);
-
-        verify(mockExecutor, times(1)).submit(any(Runnable.class));
     }
 
     @Test

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairTest.java
@@ -66,14 +66,12 @@ public class AutoRepairTest extends CQLTester
     @Test
     public void testSetup()
     {
-        AutoRepair instance = new AutoRepair();
-        instance.setup();
-
-        assertEquals(RepairType.values().length, instance.repairExecutors.size());
-        for (RepairType repairType : instance.repairExecutors.keySet())
+        AutoRepair.instance.setup();
+        assertEquals(RepairType.values().length, AutoRepair.instance.repairExecutors.size());
+        for (RepairType repairType : AutoRepair.instance.repairExecutors.keySet())
         {
-            int expectedTasks = instance.repairExecutors.get(repairType).getPendingTaskCount()
-                    + instance.repairExecutors.get(repairType).getActiveTaskCount();
+            int expectedTasks = AutoRepair.instance.repairExecutors.get(repairType).getPendingTaskCount()
+                    + AutoRepair.instance.repairExecutors.get(repairType).getActiveTaskCount();
             assertTrue(String.format("Expected > 0 task in queue for %s but was %s", repairType, expectedTasks),
                          expectedTasks > 0);
         }
@@ -82,18 +80,16 @@ public class AutoRepairTest extends CQLTester
     @Test
     public void testSafeGuardSetupCall()
     {
-        AutoRepair instance = new AutoRepair();
-
         // only one should be setup, and rest should be ignored
-        instance.setup();
-        instance.setup();
-        instance.setup();
+        AutoRepair.instance.setup();
+        AutoRepair.instance.setup();
+        AutoRepair.instance.setup();
 
-        assertEquals(RepairType.values().length, instance.repairExecutors.size());
-        for (RepairType repairType : instance.repairExecutors.keySet())
+        assertEquals(RepairType.values().length, AutoRepair.instance.repairExecutors.size());
+        for (RepairType repairType : AutoRepair.instance.repairExecutors.keySet())
         {
-            int expectedTasks = instance.repairExecutors.get(repairType).getPendingTaskCount()
-                                + instance.repairExecutors.get(repairType).getActiveTaskCount();
+            int expectedTasks = AutoRepair.instance.repairExecutors.get(repairType).getPendingTaskCount()
+                                + AutoRepair.instance.repairExecutors.get(repairType).getActiveTaskCount();
             assertTrue(String.format("Expected > 0 task in queue for %s but was %s", repairType, expectedTasks),
                        expectedTasks > 0);
         }
@@ -106,8 +102,8 @@ public class AutoRepairTest extends CQLTester
         DatabaseDescriptor.setCDCOnRepairEnabled(true);
         DatabaseDescriptor.setCDCEnabled(true);
 
-        AutoRepair instance = new AutoRepair();
-        instance.setup();
+        AutoRepair.instance.isSetupDone = false;
+        AutoRepair.instance.setup();
     }
 
     @Test
@@ -117,8 +113,7 @@ public class AutoRepairTest extends CQLTester
         DatabaseDescriptor.getAutoRepairConfig().setMaterializedViewRepairEnabled(RepairType.INCREMENTAL, false);
         DatabaseDescriptor.setCDCOnRepairEnabled(false);
         DatabaseDescriptor.setMaterializedViewsOnRepairEnabled(true);
-        AutoRepair instance = new AutoRepair();
-        instance.setup();
+        AutoRepair.instance.setup();
     }
 
     @Test(expected = ConfigurationException.class)
@@ -128,8 +123,8 @@ public class AutoRepairTest extends CQLTester
         DatabaseDescriptor.getAutoRepairConfig().setMaterializedViewRepairEnabled(RepairType.INCREMENTAL, true);
         DatabaseDescriptor.setCDCOnRepairEnabled(false);
         DatabaseDescriptor.setMaterializedViewsOnRepairEnabled(true);
-        AutoRepair instance = new AutoRepair();
-        instance.setup();
+        AutoRepair.instance.isSetupDone = false;
+        AutoRepair.instance.setup();
     }
 
     @Test


### PR DESCRIPTION
- Create AutoRepair executors only if enabled
- Use TokenRingUtils.getPrimaryRangesForEndpoint instead of StorageService.instance.getPrimaryRanges
- Remove dead code
- A few other nits

The [Cassandra Jira](https://issues.apache.org/jira/projects/CASSANDRA/issues/CASSANDRA-20531)

