### PR TITLE
AutoRepair Port CASSANDRA-20586/CASSANDRA-20620/CASSANDRA-20622

### DIFF
--- a/conf/cassandra.yaml
+++ b/conf/cassandra.yaml
@@ -1998,7 +1998,7 @@ drop_compact_storage_enabled: false
 #     force_repair_new_node: false
 #     # Threshold to skip repairing tables with too many SSTables. Defaults to 10,000 SSTables to avoid penalizing good
 #     # tables.
-#     sstable_upper_threshold: 10000
+#     sstable_upper_threshold: 50000
 #     # Maximum time allowed for repairing one table on a given node. If exceeded, the repair proceeds to the
 #     # next table.
 #     table_max_repair_time: 6h

--- a/doc/modules/cassandra/managing/operating/auto_repair.adoc
+++ b/doc/modules/cassandra/managing/operating/auto_repair.adoc
@@ -207,7 +207,7 @@ node. Defaults to true and is only evaluated when allow_parallel_replica_repair 
 immediately after a restart.
 | repair_session_timeout | 3h | Timeout for retrying stuck repair sessions.
 | force_repair_new_node | false | Force immediate repair on new nodes after they join the ring.
-| sstable_upper_threshold | 10000 | Threshold to skip repairing tables with too many SSTables.
+| sstable_upper_threshold | 50000 | Threshold to skip repairing tables with too many SSTables.
 | table_max_repair_time | 6h | Maximum time allowed for repairing one table on a given node. If exceeded, the repair
 proceeds to the next table.
 | ignore_dcs | [] | Avoid running repairs in specific data centers. By default, repairs run in all data centers. Specify
@@ -365,7 +365,7 @@ configuration for repair_type: full
 	min_repair_interval: 24h
 	repair_by_keyspace: true
 	number_of_repair_threads: 1
-	sstable_upper_threshold: 10000
+	sstable_upper_threshold: 50000
 	table_max_repair_time: 6h
 	ignore_dcs: []
 	repair_primary_token_range_only: true
@@ -387,7 +387,7 @@ configuration for repair_type: incremental
 	min_repair_interval: 1h
 	repair_by_keyspace: true
 	number_of_repair_threads: 1
-	sstable_upper_threshold: 10000
+	sstable_upper_threshold: 50000
 	table_max_repair_time: 6h
 	ignore_dcs: []
 	repair_primary_token_range_only: true

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -469,7 +469,7 @@ public class AutoRepair
         repairState.setSucceededTokenRangesCount(collectedRepairStats.succeededTokenRanges);
         repairState.setSkippedTokenRangesCount(collectedRepairStats.skippedTokenRanges);
         repairState.setSkippedTablesCount(collectedRepairStats.skippedTables);
-        repairState.setNodeRepairTimeInSec((int) TimeUnit.MILLISECONDS.toSeconds(repairScheduleElapsedInMillis));
+        repairState.setNodeRepairTimeInSec((int) TimeUnit.MILLISECONDS.toSeconds(timeFunc.get() - startTimeInMillis));
         long timeInHours = TimeUnit.SECONDS.toHours(repairState.getNodeRepairTimeInSec());
         logger.info("Local {} repair time {} hour(s), stats: repairKeyspaceCount {}, " +
                     "repairTokenRangesSuccessCount {}, repairTokenRangesFailureCount {}, " +

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepair.java
@@ -196,7 +196,7 @@ public class AutoRepair
                 boolean primaryRangeOnly = config.getRepairPrimaryTokenRangeOnly(repairType)
                                            && turn != MY_TURN_FORCE_REPAIR;
 
-                long startTime = timeFunc.get();
+                long startTimeInMillis = timeFunc.get();
                 logger.info("My host id: {}, my turn to run repair...repair primary-ranges only? {}", myId,
                             config.getRepairPrimaryTokenRangeOnly(repairType));
                 AutoRepairUtils.updateStartAutoRepairHistory(repairType, myId, timeFunc.get(), turn);
@@ -242,7 +242,7 @@ public class AutoRepair
                     repairKeyspace(repairType, primaryRangeOnly, repairAssignments.getKeyspaceName(), repairAssignments.getRepairAssignments(), collectedRepairStats);
                 }
 
-                cleanupAndUpdateStats(turn, repairType, repairState, myId, startTime, collectedRepairStats);
+                cleanupAndUpdateStats(turn, repairType, repairState, myId, startTimeInMillis, collectedRepairStats);
             }
             else
             {
@@ -449,7 +449,7 @@ public class AutoRepair
     }
 
     private void cleanupAndUpdateStats(RepairTurn turn, AutoRepairConfig.RepairType repairType, AutoRepairState repairState, UUID myId,
-                                       long startTime, CollectedRepairStats collectedRepairStats) throws InterruptedException
+                                       long startTimeInMillis, CollectedRepairStats collectedRepairStats) throws InterruptedException
     {
         //if it was due to priority then remove it now
         if (turn == MY_TURN_DUE_TO_PRIORITY)
@@ -457,12 +457,19 @@ public class AutoRepair
             logger.info("Remove current host from priority list");
             AutoRepairUtils.removePriorityStatus(repairType, myId);
         }
-
+        long repairScheduleElapsedInMillis = timeFunc.get() - startTimeInMillis;
+        if (repairScheduleElapsedInMillis < SLEEP_IF_REPAIR_FINISHES_QUICKLY.toMilliseconds())
+        {
+            //If repair finished quickly, happens for Cassndra cluster with empty (or tiny) data, in such cases,
+            //wait for some duration so that the JMX metrics can detect the repairInProgress
+            logger.info("Wait for {}ms for repair type {}.", SLEEP_IF_REPAIR_FINISHES_QUICKLY.toMilliseconds() - repairScheduleElapsedInMillis, repairType);
+            Thread.sleep(SLEEP_IF_REPAIR_FINISHES_QUICKLY.toMilliseconds() - repairScheduleElapsedInMillis);
+        }
         repairState.setFailedTokenRangesCount(collectedRepairStats.failedTokenRanges);
         repairState.setSucceededTokenRangesCount(collectedRepairStats.succeededTokenRanges);
         repairState.setSkippedTokenRangesCount(collectedRepairStats.skippedTokenRanges);
         repairState.setSkippedTablesCount(collectedRepairStats.skippedTables);
-        repairState.setNodeRepairTimeInSec((int) TimeUnit.MILLISECONDS.toSeconds(timeFunc.get() - startTime));
+        repairState.setNodeRepairTimeInSec((int) TimeUnit.MILLISECONDS.toSeconds(repairScheduleElapsedInMillis));
         long timeInHours = TimeUnit.SECONDS.toHours(repairState.getNodeRepairTimeInSec());
         logger.info("Local {} repair time {} hour(s), stats: repairKeyspaceCount {}, " +
                     "repairTokenRangesSuccessCount {}, repairTokenRangesFailureCount {}, " +
@@ -477,13 +484,7 @@ public class AutoRepair
                         TimeUnit.SECONDS.toDays(repairState.getClusterRepairTimeInSec()));
         }
         repairState.setLastRepairTime(timeFunc.get());
-        if (timeInHours == 0 && SLEEP_IF_REPAIR_FINISHES_QUICKLY.toSeconds() > 0)
-        {
-            //If repair finished quickly, happens for an empty instance, in such case
-            //wait for some duration so that the JMX metrics can detect the repairInProgress
-            logger.info("Wait for {} for repair type {}.", SLEEP_IF_REPAIR_FINISHES_QUICKLY, repairType);
-            Thread.sleep(SLEEP_IF_REPAIR_FINISHES_QUICKLY.toMilliseconds());
-        }
+
         repairState.setRepairInProgress(false);
         AutoRepairUtils.updateFinishAutoRepairHistory(repairType, myId, timeFunc.get());
     }

--- a/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
+++ b/src/java/org/apache/cassandra/repair/autorepair/AutoRepairConfig.java
@@ -451,7 +451,7 @@ public class AutoRepairConfig implements Serializable
             opts.parallel_repair_percentage = 3;
             opts.allow_parallel_replica_repair = false;
             opts.allow_parallel_replica_repair_across_schedules = true;
-            opts.sstable_upper_threshold = 10000;
+            opts.sstable_upper_threshold = 50000;
             opts.ignore_dcs = new HashSet<>();
             opts.repair_primary_token_range_only = true;
             opts.force_repair_new_node = false;

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerDisallowParallelReplicaRepairAcrossSchedulesTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerDisallowParallelReplicaRepairAcrossSchedulesTest.java
@@ -34,6 +34,7 @@ import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.repair.autorepair.AutoRepair;
 import org.apache.cassandra.repair.autorepair.AutoRepairConfig;
 import org.apache.cassandra.service.AutoRepairService;
+import org.apache.cassandra.utils.FBUtilities;
 
 import static org.junit.Assert.assertEquals;
 
@@ -117,7 +118,6 @@ public class AutoRepairSchedulerDisallowParallelReplicaRepairAcrossSchedulesTest
         cluster.forEach(i -> i.runOnInstance(() -> {
             // Expect contention on incremental repair across schedules
             AutoRepairMetrics incrementalMetrics = AutoRepairMetricsManager.getMetrics(AutoRepairConfig.RepairType.INCREMENTAL);
-
             while (incrementalMetrics.repairDelayedByReplica.getCount() <= 0)
             {
                 try

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerDisallowParallelReplicaRepairAcrossSchedulesTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerDisallowParallelReplicaRepairAcrossSchedulesTest.java
@@ -34,7 +34,6 @@ import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.repair.autorepair.AutoRepair;
 import org.apache.cassandra.repair.autorepair.AutoRepairConfig;
 import org.apache.cassandra.service.AutoRepairService;
-import org.apache.cassandra.utils.FBUtilities;
 
 import static org.junit.Assert.assertEquals;
 
@@ -118,6 +117,7 @@ public class AutoRepairSchedulerDisallowParallelReplicaRepairAcrossSchedulesTest
         cluster.forEach(i -> i.runOnInstance(() -> {
             // Expect contention on incremental repair across schedules
             AutoRepairMetrics incrementalMetrics = AutoRepairMetricsManager.getMetrics(AutoRepairConfig.RepairType.INCREMENTAL);
+
             while (incrementalMetrics.repairDelayedByReplica.getCount() <= 0)
             {
                 try

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
@@ -45,6 +45,7 @@ import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.repair.autorepair.AutoRepair;
 import org.apache.cassandra.repair.autorepair.AutoRepairConfig;
 import org.apache.cassandra.service.AutoRepairService;
+import org.apache.cassandra.utils.FBUtilities;
 
 import static org.apache.cassandra.schema.SchemaConstants.DISTRIBUTED_KEYSPACE_NAME;
 import static org.junit.Assert.assertEquals;
@@ -79,11 +80,11 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
                                                                     ImmutableMap.of(
                                                                     "initial_scheduler_delay", "5s",
                                                                     "enabled", "true",
-                                                                    "parallel_repair_count", "2",
+                                                                    "parallel_repair_count", "3",
                                                                     // Allow parallel replica repair to allow replicas
                                                                     // to execute full repair at same time.
                                                                     "allow_parallel_replica_repair", "true",
-                                                                    "min_repair_interval", "15s"),
+                                                                    "min_repair_interval", "5s"),
                                                                     AutoRepairConfig.RepairType.INCREMENTAL.getConfigName(),
                                                                     ImmutableMap.of(
                                                                     "initial_scheduler_delay", "5s",
@@ -139,9 +140,11 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
         logger.info("Repair setup done");
         // validate that the repair ran on all nodes
         cluster.forEach(i -> i.runOnInstance(() -> {
+            String broadcastAddress  = FBUtilities.getJustBroadcastAddress().toString();
+
             // Reduce sleeping if repair finishes quickly to speed up test but make it non-zero to provoke some
             // contention.
-            AutoRepair.SLEEP_IF_REPAIR_FINISHES_QUICKLY = new DurationSpec.IntSecondsBound("1s");
+            AutoRepair.SLEEP_IF_REPAIR_FINISHES_QUICKLY = new DurationSpec.IntSecondsBound("2s");
 
             AutoRepairMetrics incrementalMetrics = AutoRepairMetricsManager.getMetrics(AutoRepairConfig.RepairType.INCREMENTAL);
             while (incrementalMetrics.nodeRepairTimeInSec.getValue().longValue() <= 0)

--- a/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
+++ b/test/distributed/org/apache/cassandra/distributed/test/repair/AutoRepairSchedulerTest.java
@@ -45,7 +45,6 @@ import org.apache.cassandra.distributed.test.TestBaseImpl;
 import org.apache.cassandra.repair.autorepair.AutoRepair;
 import org.apache.cassandra.repair.autorepair.AutoRepairConfig;
 import org.apache.cassandra.service.AutoRepairService;
-import org.apache.cassandra.utils.FBUtilities;
 
 import static org.apache.cassandra.schema.SchemaConstants.DISTRIBUTED_KEYSPACE_NAME;
 import static org.junit.Assert.assertEquals;
@@ -140,14 +139,15 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
         logger.info("Repair setup done");
         // validate that the repair ran on all nodes
         cluster.forEach(i -> i.runOnInstance(() -> {
-            String broadcastAddress  = FBUtilities.getJustBroadcastAddress().toString();
-
             // Reduce sleeping if repair finishes quickly to speed up test but make it non-zero to provoke some
             // contention.
             AutoRepair.SLEEP_IF_REPAIR_FINISHES_QUICKLY = new DurationSpec.IntSecondsBound("2s");
 
             AutoRepairMetrics incrementalMetrics = AutoRepairMetricsManager.getMetrics(AutoRepairConfig.RepairType.INCREMENTAL);
-            while (incrementalMetrics.nodeRepairTimeInSec.getValue().longValue() <= 0)
+            // Since the AutoRepair sleeps up to SLEEP_IF_REPAIR_FINISHES_QUICKLY if the repair finishes quickly,
+            // so the "nodeRepairTimeInSec" metric should at least be greater than or equal to
+            // SLEEP_IF_REPAIR_FINISHES_QUICKLY
+            while (incrementalMetrics.nodeRepairTimeInSec.getValue().longValue() <= 1)
             {
                 try
                 {
@@ -179,7 +179,10 @@ public class AutoRepairSchedulerTest extends TestBaseImpl
             assertEquals(0L, incrementalMetrics.repairDelayedBySchedule.getCount());
 
             AutoRepairMetrics fullMetrics = AutoRepairMetricsManager.getMetrics(AutoRepairConfig.RepairType.FULL);
-            while (fullMetrics.nodeRepairTimeInSec.getValue().longValue() <= 0)
+            // Since the AutoRepair sleeps up to SLEEP_IF_REPAIR_FINISHES_QUICKLY if the repair finishes quickly,
+            // so the "nodeRepairTimeInSec" metric should at least be greater than or equal to
+            // SLEEP_IF_REPAIR_FINISHES_QUICKLY
+            while (fullMetrics.nodeRepairTimeInSec.getValue().longValue() <= 1)
             {
                 try
                 {

--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairConfigTest.java
@@ -474,7 +474,7 @@ public class AutoRepairConfigTest extends CQLTester
         assertEquals(Integer.valueOf(1), options.number_of_repair_threads);
         assertEquals(Integer.valueOf(3), options.parallel_repair_count);
         assertEquals(Integer.valueOf(3), options.parallel_repair_percentage);
-        assertEquals(Integer.valueOf(10000), options.sstable_upper_threshold);
+        assertEquals(Integer.valueOf(50000), options.sstable_upper_threshold);
         assertEquals(new HashSet<>(), options.ignore_dcs);
         assertTrue(options.repair_primary_token_range_only);
         assertFalse(options.force_repair_new_node);
@@ -495,7 +495,7 @@ public class AutoRepairConfigTest extends CQLTester
         assertEquals(Integer.valueOf(1), config.global_settings.number_of_repair_threads);
         assertEquals(Integer.valueOf(3), config.global_settings.parallel_repair_count);
         assertEquals(Integer.valueOf(3), config.global_settings.parallel_repair_percentage);
-        assertEquals(Integer.valueOf(10000), config.global_settings.sstable_upper_threshold);
+        assertEquals(Integer.valueOf(50000), config.global_settings.sstable_upper_threshold);
         assertEquals(new HashSet<>(), config.global_settings.ignore_dcs);
         assertTrue(config.global_settings.repair_primary_token_range_only);
         assertFalse(config.global_settings.force_repair_new_node);


### PR DESCRIPTION
Backport the following commits from _trunk_ to the 4.1 fork of AutoRepair.

```
commit f6eb4a6b31d06108f073dba7dfa04732d2abbf7b (HEAD -> trunk, origin/trunk, origin/HEAD)
Author: jaydeepkumar1984 <chovatia.jaydeep@gmail.com>
Date:   Mon May 5 18:39:07 2025 -0700

    Fix a bug in AutoRepair duration metric calculation if schedule finishes quickly
    
    patch by Jaydeepkumar Chovatia; reviewed by Andy Tolbert for CASSANDRA-20622

commit f2bf017e6dd20fb6ba7e42a9a6e5cae4e92f8a0c
Author: jaydeepkumar1984 <chovatia.jaydeep@gmail.com>
Date:   Mon May 5 11:23:26 2025 -0700

    Fix AutoRepair Flaky InJvm dtest
    
    Patch by Jaydeepkumar Chovatia; Reviewed by Andy Tolbert, Chris Lohfink for CASSANDRA-20620

commit 58d1cc9b1e23c651513390c4ab50da6f5ae104d8
Author: jaydeepkumar1984 <chovatia.jaydeep@gmail.com>
Date:   Thu Apr 24 12:04:22 2025 -0700

    Increasing default for auto_repair.sstable_upper_threshold considering large Cassandra tables

```

The [Cassandra Jira CASSANDRA-20586](https://issues.apache.org/jira/projects/CASSANDRA/issues/CASSANDRA-20586)
The [Cassandra Jira CASSANDRA-20620](https://issues.apache.org/jira/projects/CASSANDRA/issues/CASSANDRA-20620)
The [Cassandra Jira CASSANDRA-20622](https://issues.apache.org/jira/projects/CASSANDRA/issues/CASSANDRA-20622)

