### PR TITLE
No need to evict already prepared statements, as it creates a race co…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,5 @@
 5.0.7
+ * No need to evict already prepared statements, as it creates a race condition between multiple threads (CASSANDRA-17401)
  * Fix CQLSSTableWriter serialization of vector of date and time (CASSANDRA-20979)
  * Correctly calculate default for FailureDetector max interval (CASSANDRA-21025)
  * Adding missing configs in system_views.settings to be backward compatible (CASSANDRA-20863)

--- a/src/java/org/apache/cassandra/cql3/QueryProcessor.java
+++ b/src/java/org/apache/cassandra/cql3/QueryProcessor.java
@@ -751,13 +751,6 @@ public class QueryProcessor implements QueryHandler
                 return createResultMessage(hashWithKeyspace, cachedWithKeyspace);
             }
         }
-        else
-        {
-            // Make sure the missing one is going to be eventually re-prepared
-            evictPrepared(hashWithKeyspace);
-            evictPrepared(hashWithoutKeyspace);
-        }
-
         Prepared prepared = parseAndPrepare(queryString, clientState, false);
         CQLStatement statement = prepared.statement;
 

--- a/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/PreparedStatementTest.java
+++ b/test/unit/org/apache/cassandra/cql3/validation/miscellaneous/PreparedStatementTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.cassandra.cql3.validation.miscellaneous;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.cassandra.cql3.CQLTester;
+import org.apache.cassandra.cql3.QueryProcessor;
+import org.apache.cassandra.service.ClientState;
+import org.apache.cassandra.transport.messages.ResultMessage;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class PreparedStatementTest extends CQLTester
+{
+    private static final int NUM_THREADS = 50;
+    private final CountDownLatch startLatch = new CountDownLatch(1);
+    private final CountDownLatch finishLatch = new CountDownLatch(NUM_THREADS);
+
+    @Test
+    public void testPreparedStatementStaysInCache() throws Throwable
+    {
+        execute("CREATE TABLE " + KEYSPACE + ".test_fullyqualified(a int primary key, b int)");
+
+        ClientState state = ClientState.forInternalCalls();
+        Assert.assertEquals(0, QueryProcessor.instance.getPreparedStatements().size());
+        final ResultMessage.Prepared[] preparedSelect = new ResultMessage.Prepared[NUM_THREADS];
+        AtomicBoolean preparedStatementPresentInCache = new AtomicBoolean(true);
+        for (int i = 0; i < NUM_THREADS; i++)
+        {
+            int threadId = i;
+            Thread thread = new Thread(() -> {
+                try
+                {
+                    // Wait until the start signal is given
+                    startLatch.await();
+
+                    // Code to be executed in each thread
+                    preparedSelect[threadId] = QueryProcessor.instance.prepare(
+                    String.format("SELECT b FROM %s.test_fullyqualified where a = 10", KEYSPACE), state);
+                    Assert.assertNotNull(preparedSelect[threadId].statementId);
+                    if(!QueryProcessor.instance.getPreparedStatements().containsKey(preparedSelect[threadId].statementId))
+                    {
+                        preparedStatementPresentInCache.set(false);
+                    }
+                }
+                catch (InterruptedException e)
+                {
+                    Thread.currentThread().interrupt();
+                }
+                finally
+                {
+                    // Signal that this thread has finished
+                    finishLatch.countDown();
+                }
+                Assert.fail();
+            });
+            thread.start();
+        }
+
+        // Signal all threads to start
+        startLatch.countDown();
+
+        // Wait for all threads to finish
+        finishLatch.await();
+        Assert.assertTrue(preparedStatementPresentInCache.get());
+    }
+}


### PR DESCRIPTION
As part of [CASSANDRA-17248](https://issues.apache.org/jira/browse/CASSANDRA-17248) (in C* 4.0.2), the following code was introduced in [QueryProcessor.java](https://github.com/apache/cassandra/commit/242f7f9b18db77bce36c9bba00b2acda4ff3209e#r137491766)

```
// Make sure the missing one is going to be eventually re-prepared                
evictPrepared(hashWithKeyspace);                
evictPrepared(hashWithoutKeyspace); 
```
This code could very well create a race condition between two calls of [QueryProcessor::prepare](https://github.com/apache/cassandra/blob/cassandra-4.0/src/java/org/apache/cassandra/cql3/QueryProcessor.java#L575) call in which one thread is adding and another thread is silently removing from the cache. Imagine there are thousands of threads calling the API, and then it might be possible for one thread to update the cache and another thread to remove it.

If we look at the code of [Cassandra 3.0.25](https://github.com/apache/cassandra/blob/cassandra-3.0.25/src/java/org/apache/cassandra/cql3/QueryProcessor.java#L391), then such eviction was not present. Hence, this is a regression for the post 4.0.2 version of Cassandra. To fix this issue, we should not evict the cache entries, i.e., the above-mentioned code path introduced since C* 4.0.2 is no longer required on trunk/5.0, as discussed in the [ticket](https://issues.apache.org/jira/browse/CASSANDRA-17401?focusedCommentId=18046549&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-18046549).

For the 4.0 branch, we will keep the eviction logic but optimize it further to address [CASSANDRA-17401](https://issues.apache.org/jira/browse/CASSANDRA-17401), as it is essential for folks on pre-4.0.1 trying to upgrade to the latest 4.0 version.



[Cassandra-17401](https://issues.apache.org/jira/browse/CASSANDRA-17401)

**Reproducing** this is extremely tricky because it totally depends on the timing of the multiple threads, here is the pull request that reproduces it: https://github.com/apache/cassandra/pull/3058

