### PR TITLE
CASSANDRA-21115 follow-up: fix checkstyle-test unused-import failure

### DIFF
--- a/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairTest.java
+++ b/test/unit/org/apache/cassandra/repair/autorepair/AutoRepairTest.java
@@ -40,7 +40,6 @@ import org.apache.cassandra.repair.autorepair.AutoRepairConfig.RepairType;
 import org.apache.cassandra.schema.SchemaConstants;
 import org.apache.cassandra.schema.SchemaTestUtil;
 import org.apache.cassandra.schema.SystemDistributedKeyspace;
-import org.apache.cassandra.service.AutoRepairService;
 import org.apache.cassandra.service.StorageService;
 import org.apache.cassandra.utils.FBUtilities;
 


### PR DESCRIPTION
## Summary

Follow-up to #69 (merged as `ebc10e9`). The merged commit series introduced an unused import of `org.apache.cassandra.service.AutoRepairService` in `AutoRepairTest.java`, which fails `checkstyle-test`:

```
[ERROR] test/unit/.../AutoRepairTest.java:43:8:
  Unused import - org.apache.cassandra.service.AutoRepairService. [UnusedImports]
```

The import was pulled in during the cherry-pick conflict resolution (union of imports from trunk). It is used only on trunk (5.1), where `@Before setup()` calls `AutoRepairService.setup();`. This branch does not have that call, so the import is dead code.

The fix in #69 (`8ba7e12609`) was pushed 29 minutes *after* Jaydeep merged the PR at `ebc10e9`, so it did not get carried along. This PR re-lands just that one-line deletion on top of the current `auto_repair_v2_on_4_1` tip.

## Change

- Delete `import org.apache.cassandra.service.AutoRepairService;` from `test/unit/org/apache/cassandra/repair/autorepair/AutoRepairTest.java`.

## Test plan

Locally on JDK 11 (Amazon Corretto 11.0.30, `CASSANDRA_USE_JDK11=true`):

- [x] `ant realclean && ant build` — BUILD SUCCESSFUL (checkstyle clean)
- [x] `ant build-test` — BUILD SUCCESSFUL (checkstyle-test clean; without this fix it fails on `AutoRepairTest.java:43`)
- [x] `ant testsome -Dtest.name=org.apache.cassandra.repair.autorepair.AutoRepairTest` — 9/9 passing
- [x] `AutoRepairStateTest` (72/72), `AutoRepairUtilsTest` (33/33), `AutoRepairParameterizedTest` (90/90) — all pass

Verified on JDK 8 (Amazon Corretto 8.492) as well: main build + test compile + checkstyle-test all clean;
